### PR TITLE
Present option for projects, update project ordering, support removed simple-icons icons, small tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a personal portfolio site made by me using Java Spring Boot. It utilizes
 
 **Link:** <a href="https://jasonpyau.com">jasonpyau.com/</a>
 <br>
-**API Documentation:** <a href="https://app.swaggerhub.com/apis-docs/JASONYAU/jasonpyau.com/1.0.0#/">swaggerhub.com/apis-docs/JASONYAU/jasonpyau.com/1.0.0#/</a>
+**API Documentation:** <a href="https://app.swaggerhub.com/apis-docs/jasonpyau-com/jasonpyau.com/1.0.0">https://app.swaggerhub.com/apis-docs/jasonpyau-com/jasonpyau.com/1.0.0</a>
 
 This website is hosted on my Raspberry Pi, using Cloudflare's free tunneling services for SSL certificate and DDoS protection and GitHub Actions for continuous deployment after each Git push.
 

--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -27,8 +27,10 @@ public class AdminPanel {
 
     private static void newProject() {
         String body = getProjectBody();
-        apiCall("/projects/new", body, "POST", true);
-        updateLastUpdated(false);
+        boolean success = apiCall("/projects/new", body, "POST", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
     }
 
     private static void updateProject() {
@@ -37,16 +39,20 @@ public class AdminPanel {
         scan.nextLine();
         System.out.println("You may leave blank any fields you don't want to update.");
         String body = getProjectBody();
-        apiCall("/projects/update/"+id, body, "PATCH", true);
-        updateLastUpdated(false);
+        boolean success = apiCall("/projects/update/"+id, body, "PATCH", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
     }
 
     private static void deleteProject() {
         System.out.println("Input the id of the project you'd like to delete:");
         int id = scan.nextInt();
         scan.nextLine();
-        apiCall("/projects/delete/"+id, "{ }", "DELETE", true);
-        updateLastUpdated(false);
+        boolean success = apiCall("/projects/delete/"+id, "{ }", "DELETE", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
     }
 
     private static void getProjects() {
@@ -81,16 +87,19 @@ public class AdminPanel {
         String body = "{\"name\": \""+name+"\"," +
                         "\"type\": \""+type+"\"," +
                         "\"simpleIconsIconSlug\": \""+simpleIconsIconSlug+"\"}";
-        apiCall("/skills/new", body, "POST", true);
-        updateLastUpdated(false);
-        
+        boolean success = apiCall("/skills/new", body, "POST", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
     }
 
     private static void deleteSkill() {
         System.out.println("Input name of the skill:");
         String name = URLEncoder.encode(scan.nextLine(), StandardCharsets.UTF_8).replace("+", "%20");
-        apiCall(String.format("/skills/delete/%s", name), "{ }", "DELETE", true);
-        updateLastUpdated(false);
+        boolean success = apiCall(String.format("/skills/delete/%s", name), "{ }", "DELETE", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
     }
 
     private static void viewSkills() {
@@ -101,8 +110,10 @@ public class AdminPanel {
         System.out.println("Input text:");
         String text = scan.nextLine();
         String body = "{\"text\": \""+text+"\"}";
-        apiCall("/about_me/update", body, "PUT", true);
-        updateLastUpdated(false);
+        boolean success = apiCall("/about_me/update", body, "PUT", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
     }
 
     private static void getAboutMe() {
@@ -171,7 +182,7 @@ public class AdminPanel {
         apiCall("/shut_down", "{ }", "DELETE", true);
     }
 
-    private static void apiCall(String endpoint, String body, String method, boolean showConfirmation) {
+    private static boolean apiCall(String endpoint, String body, String method, boolean showConfirmation) {
         if (showConfirmation) {
             System.out.println("This will send a "+method+" request with the body: \n");
             System.out.println(body);
@@ -186,7 +197,7 @@ public class AdminPanel {
                 case "n":
                 default:
                     System.out.println("Exited.");
-                    return;
+                    return false;
             }
         }
         try {
@@ -206,7 +217,9 @@ public class AdminPanel {
             }
         } catch (Exception e) {
             System.out.println("Error in sending HTTP Request:\n" + e);
+            return false;
         }
+        return true;
     }
 
     private static void printBlogsMenu() {

--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -82,7 +82,10 @@ public class AdminPanel {
         apiCall("/skills/valid_types", "{ }", "GET", false);
         System.out.println("These are the valid types. Input the type of skill:");
         String type = scan.nextLine();
-        System.out.println("Input the Simple Icons slug for the skill (not required). Read more about it here: https://www.npmjs.com/package/simple-icons https://github.com/simple-icons/simple-icons/blob/develop/slugs.md");
+        System.out.println("Input the Simple Icons slug for the skill (optional). See here:\n" +
+                            "https://github.com/simple-icons/simple-icons/blob/master/slugs.md\n\n" +
+                            "Additionally, icons for Microsoft technologies and Java were removed in Simple Icons version >= 7.0.0. You may also use:\n" +
+                            "https://github.com/simple-icons/simple-icons/blob/6.23.0/slugs.md\n");
         String simpleIconsIconSlug = scan.nextLine();
         String body = "{\"name\": \""+name+"\"," +
                         "\"type\": \""+type+"\"," +

--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -354,8 +354,17 @@ public class AdminPanel {
         System.out.println("Input startDate ('MM/YYYY') of project");
         input = scan.nextLine();
         sb.append("\"startDate\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
-        System.out.println("Input endDate ('MM/YYYY') of project");
+        System.out.println("Is the project currently being worked on? [true/false]");
         input = scan.nextLine();
+        sb.append("\"present\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
+        if (input.equals("true")) {
+            // Currently, endDate is a required field even if present = true. 
+            // The server has logic to always update the endDate to the current month. 
+            input = "12/2099";
+        } else {
+            System.out.println("Input endDate ('MM/YYYY') of project");
+            input = scan.nextLine();
+        }
         sb.append("\"endDate\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
         System.out.println("Input link to the project:");
         input = scan.nextLine();

--- a/backend/src/main/java/com/jasonpyau/controller/ProjectController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/ProjectController.java
@@ -76,7 +76,7 @@ public class ProjectController {
     @CrossOrigin
     public ResponseEntity<HashMap<String, Object>> newProjectSkill(HttpServletRequest request, 
                                                                     @PathVariable("id") Integer id, 
-                                                                    @RequestParam(required = true) @Size(min = 1, max = 15, message = Skill.SKILL_NAME_ERROR) String skillName) {
+                                                                    @RequestParam(required = true) @Size(min = 1, max = 25, message = Skill.SKILL_NAME_ERROR) String skillName) {
         String errorMessage = projectService.newProjectSkill(skillName, id);
         if (errorMessage != null) {
             return Response.errorMessage(errorMessage, HttpStatus.NOT_ACCEPTABLE);
@@ -90,7 +90,7 @@ public class ProjectController {
     @CrossOrigin
     public ResponseEntity<HashMap<String, Object>> deleteProjectSkill(HttpServletRequest request, 
                                                                     @PathVariable("id") Integer id, 
-                                                                    @RequestParam(required = true) @Size(min = 1, max = 15, message = Skill.SKILL_NAME_ERROR) String skillName) {
+                                                                    @RequestParam(required = true) @Size(min = 1, max = 25, message = Skill.SKILL_NAME_ERROR) String skillName) {
         String errorMessage = projectService.deleteProjectSkill(skillName, id);
         if (errorMessage != null) {
             return Response.errorMessage(errorMessage, HttpStatus.NOT_ACCEPTABLE);

--- a/backend/src/main/java/com/jasonpyau/entity/Skill.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Skill.java
@@ -36,7 +36,7 @@ import lombok.Setter;
 @Table(name = "skills", indexes = @Index(name = "type_name_ind", columnList = "type, name"))
 public class Skill {
 
-    public static final String SKILL_NAME_ERROR = "'name' should be between 1-15 characters.";
+    public static final String SKILL_NAME_ERROR = "'name' should be between 1-25 characters.";
     public static final String SKILL_ALREADY_EXISTS_ERROR = "Skill already exists.";
     public static final String SKILL_NOT_FOUND_ERROR = "Skill with given 'name' not found.";
     public static final String SKILL_SIMPLE_ICONS_ICON_SLUG_ERROR = "'simpleIconsIconSlug' should be between 0-50 characters.";
@@ -49,7 +49,7 @@ public class Skill {
     private Integer id;
 
     @Column(name = "name", unique = true, nullable = false)
-    @Size(min = 1, max = 15, message = SKILL_NAME_ERROR)
+    @Size(min = 1, max = 25, message = SKILL_NAME_ERROR)
     @NotBlank(message = SKILL_NAME_ERROR)
     private String name;
 

--- a/backend/src/main/java/com/jasonpyau/entity/Skill.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Skill.java
@@ -60,7 +60,8 @@ public class Skill {
     @Column(name = "simple_icons_icon_slug", nullable = true)
     @Size(max = 50, message = SKILL_SIMPLE_ICONS_ICON_SLUG_ERROR)
     // https://www.npmjs.com/package/simple-icons
-    // https://github.com/simple-icons/simple-icons/blob/develop/slugs.md
+    // https://github.com/simple-icons/simple-icons/blob/master/slugs.md
+    // https://github.com/simple-icons/simple-icons/blob/6.23.0/slugs.md
     private String simpleIconsIconSlug;
 
     @JsonIgnore

--- a/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
+++ b/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
@@ -16,6 +16,6 @@ public class CacheUtil {
     @Scheduled(fixedRate = 4, timeUnit = TimeUnit.HOURS)
     @CacheEvict(cacheNames = {SKILL_CACHE, PROJECT_CACHE, ABOUT_ME_CACHE}, allEntries = true)
     public void clearCache() {
-        System.out.println("Cleared Cache at "+DateFormat.MMddyyyyhhmmss());
+        System.out.printf("%s: Cleared Cache\n", DateFormat.MMddyyyyhhmmss());
     }
 }

--- a/backend/src/main/java/com/jasonpyau/util/DateFormat.java
+++ b/backend/src/main/java/com/jasonpyau/util/DateFormat.java
@@ -25,6 +25,12 @@ public class DateFormat {
         return dateTime;
     }
 
+    public static String MMyyyy() {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM/yyyy");
+        String dateTime = simpleDateFormat.format(new Date());
+        return dateTime;
+    }
+
     public static Long getUnixTime() {
         return System.currentTimeMillis()/1000L;
     }

--- a/backend/src/main/resources/static/css/index.css
+++ b/backend/src/main/resources/static/css/index.css
@@ -25,3 +25,7 @@
     background: rgb(25,25,112);
     background: linear-gradient(135deg, rgba(25,25,112,1) 0%, rgba(45,45,200,1) 100%);
 }
+
+#ContactMeSpinner {
+    display: none;
+}

--- a/backend/src/main/resources/static/javascript/ContactForm.js
+++ b/backend/src/main/resources/static/javascript/ContactForm.js
@@ -15,8 +15,12 @@ async function contactFormSubmit() {
         contactInfo: contactInfo,
         body: message
     };
+    document.getElementById("ContactMeSendButton").classList.add("disabled");
+    document.getElementById("ContactMeSpinner").style.display = "block";
     const result = await apiCall(url, "POST", headers, body);
     const json = await result.json();
+    document.getElementById("ContactMeSendButton").classList.remove("disabled");
+    document.getElementById("ContactMeSpinner").style.display = "none";
     const contactFormSuccessElement = document.getElementById("ContactFormSuccess");
     const contactFormErrorElement = document.getElementById("ContactFormError");
     if (result.status === 200) {

--- a/backend/src/main/resources/static/javascript/projects.js
+++ b/backend/src/main/resources/static/javascript/projects.js
@@ -23,7 +23,7 @@ addEventListener('DOMContentLoaded', async(e) => {
                 <div class="fs-6 fw-semibold fst-italic" id="DateContainer">
                     <span id="StartDate">${project.startDate}</span>
                     <span>-</span>
-                    <span id="EndDate">${project.endDate}</span>
+                    <span id="EndDate">${project.present ? "Present" : project.endDate}</span>
                 </div>
                 <div class="my-3" id="SkillsContainer">
             

--- a/backend/src/main/resources/templates/index.html
+++ b/backend/src/main/resources/templates/index.html
@@ -64,9 +64,12 @@
                     <label for="MessageInput">Message</label>
                 </div>
                 <div id="SubmitContainer" class="d-flex align-items-center flex-column">
+                    <div class="d-flex justify-content-center">
+                        <div class="spinner-border m-2" id="ContactMeSpinner" role="status"></div>
+                    </div>
                     <div class="SuccessMessage" id="ContactFormSuccess">Success</div>
                     <div class="ErrorMessage" id="ContactFormError">Error</div>
-                    <button class="btn btn-primary border-0" onclick="contactFormSubmit()" type="submit" title="Send Message">Send</button>
+                    <button class="btn btn-primary border-0" onclick="contactFormSubmit()" type="submit" title="Send Message" id="ContactMeSendButton">Send</button>
                     <div>
                         Note: This sends an email notification to me.
                     </div>

--- a/backend/src/main/resources/templates/template.html
+++ b/backend/src/main/resources/templates/template.html
@@ -82,7 +82,7 @@
             </div>
         </a>
         <div class="fs-6 my-3">
-            <a href="https://app.swaggerhub.com/apis-docs/JASONYAU/jasonpyau.com/1.0.0#/" class="NoDecoration" target="_blank" title="SwaggerHub">
+            <a href="https://app.swaggerhub.com/apis-docs/jasonpyau-com/jasonpyau.com/1.0.0" class="NoDecoration" target="_blank" title="SwaggerHub">
                 <u>
                     API Documentation
                 </u>

--- a/backend/src/test/java/com/jasonpyau/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/ProjectServiceTest.java
@@ -36,6 +36,7 @@ public class ProjectServiceTest {
                                 .description("Test Description of Project1")
                                 .startDate("05/2023")
                                 .endDate("06/2023")
+                                .present(false)
                                 .dateOrder("202305202306")
                                 .link("project.com")
                                 .build();


### PR DESCRIPTION
- Add present option for projects; admin can indicate that a project is currently being worked on
- Refactor project ordering to be based on end date, then start date
- Add functionality to support removed simple-icons icons that are used for skills. Namely, Microsoft and Java icons were removed in simple-icons version >= 7.0.0. However, this does add more overhead when loading the home page.
- Modify AdminPanel.java: 'Last Updated' does not change if API request failed/canceled
- Improve loading UI for Contact Me
- Increase max skill name length to 25
- Update SwaggerHub link