### PR TITLE
Add update and get SVG endpoints for Skills, add link attribute to Skills, add .properties for rate limit and cache configurations, section scrolling fixes

### DIFF
--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -40,6 +40,7 @@ public class AdminPanel {
         System.out.println("Input the id of the experience you'd like to update:");
         String id = scan.nextLine();
         System.out.println("You may leave blank any fields you don't want to update.");
+        System.out.println("You may input \"ERASE!!!\" to erase the current value for any optional fields.");
         String body = getExperienceBody();
         boolean success = apiCall("/experiences/update/"+id, body, "PATCH", true);
         if (success) {
@@ -143,6 +144,34 @@ public class AdminPanel {
                         "\"link\": \""+link+"\"," +
                         "\"simpleIconsIconSlug\": \""+simpleIconsIconSlug+"\"}";
         boolean success = apiCall("/skills/new", body, "POST", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
+    }
+
+    private static void updateSkill() {
+        StringBuilder sb = new StringBuilder();
+        String input;
+        System.out.println("Input name of the skill you'd like to update:");
+        input = scan.nextLine();
+        sb.append("{\"name\": "+"\""+input+"\", ");
+        System.out.println("You may leave blank any fields you don't want to update.");
+        System.out.println("You may input \"ERASE!!!\" to erase the current value for any optional fields.");
+        System.out.println("Loading valid types for a skill...");
+        apiCall("/skills/valid_types", "{ }", "GET", false);
+        System.out.println("These are the valid types. Input the type of skill:");
+        input = scan.nextLine();
+        sb.append("\"type\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
+        System.out.println("Input a link that provides more info on this skill (optional):");
+        input = scan.nextLine();
+        sb.append("\"link\": " + ((!input.isBlank()) ? input.equals("ERASE!!!") ? "\"\"" : "\""+input+"\"" : "null") + ", ");
+        System.out.println("Input the Simple Icons slug for the skill (optional). See here:\n" +
+                            "https://github.com/simple-icons/simple-icons/blob/master/slugs.md\n\n" +
+                            "Additionally, icons for Microsoft technologies and Java were removed in Simple Icons version >= 7.0.0. You may also use:\n" +
+                            "https://github.com/simple-icons/simple-icons/blob/6.23.0/slugs.md\n");
+        input = scan.nextLine();
+        sb.append("\"simpleIconsIconSlug\": " + ((!input.isBlank()) ? input.equals("ERASE!!!") ? "\"\"" : "\""+input+"\"" : "null") + "} ");
+        boolean success = apiCall("/skills/update", sb.toString(), "PATCH", true);
         if (success) {
             updateLastUpdated(false);
         }
@@ -393,21 +422,25 @@ public class AdminPanel {
             System.out.println("      SKILLS MENU      ");
             System.out.println("=======================");
             System.out.println("1.) New Skill");
-            System.out.println("2.) Delete Skill");
-            System.out.println("3.) View Skills");
-            System.out.println("4.) Back");
+            System.out.println("2.) Update Skill");
+            System.out.println("3.) Delete Skill");
+            System.out.println("4.) View Skills");
+            System.out.println("5.) Back");
             String input = scan.nextLine();
             switch (input) {
                 case "1":
                     newSkill();
                     break;
                 case "2":
-                    deleteSkill();
+                    updateSkill();
                     break;
                 case "3":
-                    viewSkills();
+                    deleteSkill();
                     break;
                 case "4":
+                    viewSkills();
+                    break;
+                case "5":
                     return;
                 default:
                     System.out.println("Invalid input.");
@@ -476,7 +509,7 @@ public class AdminPanel {
         sb.append("\"logoLink\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
         System.out.println("Input experience company link (optional):");
         input = scan.nextLine();
-        sb.append("\"companyLink\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + "} ");
+        sb.append("\"companyLink\": " + ((!input.isBlank()) ? input.equals("ERASE!!!") ? "\"\"" : "\""+input+"\"" : "null") + "} ");
         return sb.toString();
     }
 

--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -131,6 +131,8 @@ public class AdminPanel {
         apiCall("/skills/valid_types", "{ }", "GET", false);
         System.out.println("These are the valid types. Input the type of skill:");
         String type = scan.nextLine();
+        System.out.println("Input a link that provides more info on this skill (optional):");
+        String link = scan.nextLine();
         System.out.println("Input the Simple Icons slug for the skill (optional). See here:\n" +
                             "https://github.com/simple-icons/simple-icons/blob/master/slugs.md\n\n" +
                             "Additionally, icons for Microsoft technologies and Java were removed in Simple Icons version >= 7.0.0. You may also use:\n" +
@@ -138,6 +140,7 @@ public class AdminPanel {
         String simpleIconsIconSlug = scan.nextLine();
         String body = "{\"name\": \""+name+"\"," +
                         "\"type\": \""+type+"\"," +
+                        "\"link\": \""+link+"\"," +
                         "\"simpleIconsIconSlug\": \""+simpleIconsIconSlug+"\"}";
         boolean success = apiCall("/skills/new", body, "POST", true);
         if (success) {

--- a/backend/src/main/java/com/jasonpyau/annotation/RateLimit.java
+++ b/backend/src/main/java/com/jasonpyau/annotation/RateLimit.java
@@ -10,11 +10,11 @@ import java.lang.annotation.Target;
 public @interface RateLimit {
 
     public static final long CHEAP_TOKEN = 1;
-    public static final long DEFAULT_TOKEN = 2;
-    public static final long ADMIN_TOKEN = 5;
-    public static final long BIG_TOKEN = 5;
-    public static final long LARGE_TOKEN = 10;
-    public static final long EXPENSIVE_TOKEN = 25;
+    public static final long DEFAULT_TOKEN = 4;
+    public static final long ADMIN_TOKEN = 10;
+    public static final long BIG_TOKEN = 10;
+    public static final long LARGE_TOKEN = 20;
+    public static final long EXPENSIVE_TOKEN = 50;
 
     public long value() default DEFAULT_TOKEN;
 }

--- a/backend/src/main/java/com/jasonpyau/annotation/RateLimitAspect.java
+++ b/backend/src/main/java/com/jasonpyau/annotation/RateLimitAspect.java
@@ -6,6 +6,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.jasonpyau.exception.RateLimitException;
@@ -17,6 +18,9 @@ import jakarta.servlet.http.HttpServletRequest;
 @Aspect
 @Component
 public class RateLimitAspect {
+
+    @Autowired
+    private RateLimitService rateLimitService;
     
     @Around("@annotation(RateLimit)")
     public Object rateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -26,7 +30,7 @@ public class RateLimitAspect {
         for (Object arg : args) {
             if (arg instanceof HttpServletRequest) {
                 HttpServletRequest request = (HttpServletRequest)arg;
-                ConsumptionProbe consumptionProbe = RateLimitService.RateLimiter.rateLimit(request, rateLimitAnnotation.value());
+                ConsumptionProbe consumptionProbe = rateLimitService.rateLimit(request, rateLimitAnnotation.value());
                 if (!consumptionProbe.isConsumed()) {
                     throw new RateLimitException(TimeUnit.NANOSECONDS.toMillis(consumptionProbe.getNanosToWaitForRefill()));
                 }

--- a/backend/src/main/java/com/jasonpyau/controller/FrontendController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/FrontendController.java
@@ -86,7 +86,7 @@ public class FrontendController {
 
     @GetMapping({"/resume", "/resume/"})
     public String resume() throws IOException {
-        String resumeLink = env.getProperty("com.jasonpyau.resumeLink");
+        String resumeLink = env.getProperty("com.jasonpyau.resume-link");
         if (resumeLink != null && !resumeLink.isBlank()) {
             return "redirect:"+resumeLink;
         }

--- a/backend/src/main/java/com/jasonpyau/controller/SkillController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/SkillController.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,6 +43,19 @@ public class SkillController {
         }
         return new ResponseEntity<>(Response.createBody(), HttpStatus.OK);
     }
+
+    @PatchMapping(path = "/update", consumes = "application/json", produces = "application/json")
+    @AuthorizeAdmin
+    @RateLimit(RateLimit.ADMIN_TOKEN)
+    @CrossOrigin
+    public ResponseEntity<HashMap<String, Object>> updateSkill(HttpServletRequest request, @RequestBody Skill skill) {
+        String errorMessage = skillService.updateSkill(skill);
+        if (errorMessage != null) {
+            return Response.errorMessage(errorMessage, HttpStatus.NOT_ACCEPTABLE);
+        }
+        return new ResponseEntity<>(Response.createBody(), HttpStatus.OK);
+    }
+
 
     @DeleteMapping(path = "/delete/{name}", produces = "application/json")
     @AuthorizeAdmin

--- a/backend/src/main/java/com/jasonpyau/controller/SkillController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/SkillController.java
@@ -2,8 +2,10 @@ package com.jasonpyau.controller;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -75,6 +77,15 @@ public class SkillController {
     public ResponseEntity<HashMap<String, Object>> getSkills(HttpServletRequest request) {
         HashMap<String, List<Skill>> skills = skillService.getSkills();
         return new ResponseEntity<>(Response.createBody("skills", skills), HttpStatus.OK);
+    }
+
+    @GetMapping(path = "/svg/{name}", produces = "image/svg+xml")
+    @RateLimit(RateLimit.CHEAP_TOKEN)
+    @CrossOrigin
+    public ResponseEntity<String> getSkillIconSvg(HttpServletRequest request, @PathVariable("name") String skillName) {
+        return ResponseEntity.ok()
+                            .cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES))
+                            .body(skillService.getSkillIconSvg(skillName));
     }
 
     @GetMapping(path = "/valid_types", produces = "application/json")

--- a/backend/src/main/java/com/jasonpyau/entity/Skill.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Skill.java
@@ -40,8 +40,9 @@ public class Skill {
     public static final String SKILL_ALREADY_EXISTS_ERROR = "Skill already exists.";
     public static final String SKILL_NOT_FOUND_ERROR = "Skill with given 'name' not found.";
     public static final String SKILL_SIMPLE_ICONS_ICON_SLUG_ERROR = "'simpleIconsIconSlug' should be between 0-50 characters.";
-    private static final String SKILL_LINK_ERROR = "'link' should be between 0-250 characters.";
+    public static final String SKILL_LINK_ERROR = "'link' should be between 0-250 characters.";
     public static final String SKILL_TYPE_ERROR = "Invalid 'type'.";
+    public static final String SKILL_ICON_EMPTY_SVG = "";
     public static final HashSet<String> validTypes = new HashSet<>(Arrays.asList("Language", "Framework/Library", "Database", "Software"));
 
     @Id

--- a/backend/src/main/java/com/jasonpyau/entity/Skill.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Skill.java
@@ -40,6 +40,7 @@ public class Skill {
     public static final String SKILL_ALREADY_EXISTS_ERROR = "Skill already exists.";
     public static final String SKILL_NOT_FOUND_ERROR = "Skill with given 'name' not found.";
     public static final String SKILL_SIMPLE_ICONS_ICON_SLUG_ERROR = "'simpleIconsIconSlug' should be between 0-50 characters.";
+    private static final String SKILL_LINK_ERROR = "'link' should be between 0-250 characters.";
     public static final String SKILL_TYPE_ERROR = "Invalid 'type'.";
     public static final HashSet<String> validTypes = new HashSet<>(Arrays.asList("Language", "Framework/Library", "Database", "Software"));
 
@@ -56,6 +57,10 @@ public class Skill {
     @Column(name = "type", nullable = false)
     @NotBlank(message = SKILL_TYPE_ERROR)
     private String type;
+
+    @Column(name = "link", nullable = true)
+    @Size(max = 250, message = SKILL_LINK_ERROR)
+    private String link;
 
     @Column(name = "simple_icons_icon_slug", nullable = true)
     @Size(max = 50, message = SKILL_SIMPLE_ICONS_ICON_SLUG_ERROR)

--- a/backend/src/main/java/com/jasonpyau/service/AuthorizationService.java
+++ b/backend/src/main/java/com/jasonpyau/service/AuthorizationService.java
@@ -10,7 +10,7 @@ public class AuthorizationService {
 
     private static String appPassword;
 
-    @Value("${com.jasonpyau.appPassword}")
+    @Value("${com.jasonpyau.app-password}")
     @SuppressWarnings("static-access")
     public void setAppPassword(String appPassword) {
         this.appPassword = appPassword;

--- a/backend/src/main/java/com/jasonpyau/service/SkillService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SkillService.java
@@ -5,16 +5,23 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.jasonpyau.entity.Skill;
 import com.jasonpyau.repository.SkillRepository;
 import com.jasonpyau.util.CacheUtil;
 import com.jasonpyau.util.Patch;
+import com.jasonpyau.util.SkillIconSvgData;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -29,8 +36,10 @@ public class SkillService {
 
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
+    private JsonNode iconSvgData = SkillIconSvgData.get();
+
     // Returns error message if applicable, else null.
-    @CacheEvict(cacheNames = CacheUtil.SKILL_CACHE, allEntries = true)
+    @CacheEvict(cacheNames = {CacheUtil.SKILL_CACHE, CacheUtil.SKILL_ICON_SVG_CACHE}, allEntries = true)
     public String newSkill(Skill skill) {
         if (skillRepository.findSkillByName(skill.getName()).isPresent()) {
             return Skill.SKILL_ALREADY_EXISTS_ERROR;
@@ -43,7 +52,7 @@ public class SkillService {
     }
 
     // Returns error message if applicable, else null.
-    @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
+    @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.SKILL_CACHE, CacheUtil.SKILL_ICON_SVG_CACHE}, allEntries = true)
     public String updateSkill(Skill updateSkill) {
         Optional<Skill> optional = skillRepository.findSkillByName(updateSkill.getName());
         if (!optional.isPresent()) {
@@ -63,7 +72,7 @@ public class SkillService {
     }
 
     // Returns error message if applicable, else null.
-    @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
+    @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.SKILL_CACHE, CacheUtil.SKILL_ICON_SVG_CACHE}, allEntries = true)
     public String deleteSkill(String skillName) {
         Optional<Skill> optional = skillRepository.findSkillByName(skillName);
         if (!optional.isPresent()) {
@@ -81,6 +90,49 @@ public class SkillService {
             res.put(type, skillRepository.findAllSkillNameByType(type));
         }
         return res;
+    }
+
+    @Cacheable(cacheNames = CacheUtil.SKILL_ICON_SVG_CACHE)
+    public String getSkillIconSvg(String skillName) {
+        Optional<Skill> optional = skillRepository.findSkillByName(skillName);
+        if (!optional.isPresent() || optional.get().getSimpleIconsIconSlug().isBlank()) {
+            return Skill.SKILL_ICON_EMPTY_SVG;
+        }
+        Skill skill = optional.get();
+        RestClient restClient = RestClient.create();
+        try {
+            ResponseEntity<String> res = restClient
+                                        .get()
+                                        .uri("https://cdn.simpleicons.org/"+skill.getSimpleIconsIconSlug())
+                                        .retrieve()
+                                        .toEntity(String.class);
+            return res.getBody();
+        } catch (HttpClientErrorException e) {}
+        // If we got here, we used simple-icons/6.23.0.
+        try {
+            ResponseEntity<String> res = restClient
+                                        .get()
+                                        .uri("https://raw.githubusercontent.com/simple-icons/simple-icons/6.23.0/icons/"+skill.getSimpleIconsIconSlug()+".svg")
+                                        .retrieve()
+                                        .toEntity(String.class);
+            String svg = res.getBody();
+            Matcher matcher = Pattern.compile("<title>(.*?)</title>").matcher(svg);
+            if (matcher.find() && iconSvgData != null) {
+                String hex = null;
+                String title = matcher.group(1);
+                for (JsonNode data : iconSvgData) {
+                    if (data.get("title").asText().equals(title)) {
+                        hex = data.get("hex").asText();
+                        break;
+                    }
+                }
+                if (hex != null) {
+                    svg = svg.replace("<svg", String.format("<svg fill=\"%s\"", "#"+hex));
+                }
+            }
+            return svg;
+        } catch (HttpClientErrorException e) {}
+        return Skill.SKILL_ICON_EMPTY_SVG;
     }
 
     public List<String> validTypes() {

--- a/backend/src/main/java/com/jasonpyau/service/SkillService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SkillService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
@@ -13,6 +14,12 @@ import org.springframework.stereotype.Service;
 import com.jasonpyau.entity.Skill;
 import com.jasonpyau.repository.SkillRepository;
 import com.jasonpyau.util.CacheUtil;
+import com.jasonpyau.util.Patch;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 @Service
 public class SkillService {
@@ -20,11 +27,33 @@ public class SkillService {
     @Autowired
     private SkillRepository skillRepository;
 
+    private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
     // Returns error message if applicable, else null.
     @CacheEvict(cacheNames = CacheUtil.SKILL_CACHE, allEntries = true)
     public String newSkill(Skill skill) {
         if (skillRepository.findSkillByName(skill.getName()).isPresent()) {
             return Skill.SKILL_ALREADY_EXISTS_ERROR;
+        }
+        if (!skill.checkValidType()) {
+            return Skill.SKILL_TYPE_ERROR;
+        }
+        skillRepository.save(skill);
+        return null;
+    }
+
+    // Returns error message if applicable, else null.
+    @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
+    public String updateSkill(Skill updateSkill) {
+        Optional<Skill> optional = skillRepository.findSkillByName(updateSkill.getName());
+        if (!optional.isPresent()) {
+            return Skill.SKILL_NOT_FOUND_ERROR;
+        }
+        Skill skill = optional.get();
+        Patch.merge(updateSkill, skill, "id", "name");
+        Set<ConstraintViolation<Skill>> violations = validator.validate(skill);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
         }
         if (!skill.checkValidType()) {
             return Skill.SKILL_TYPE_ERROR;

--- a/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
+++ b/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
@@ -2,9 +2,12 @@ package com.jasonpyau.util;
 
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import com.jasonpyau.service.RateLimitService;
 
 @Component
 public class CacheUtil {
@@ -15,9 +18,13 @@ public class CacheUtil {
     public static final String EXPERIENCE_CACHE = "experienceCache";
     public static final String ABOUT_ME_CACHE = "aboutMeCache";
 
-    @Scheduled(fixedRate = 4, timeUnit = TimeUnit.HOURS)
+    @Autowired
+    private RateLimitService rateLimitService;
+
+    @Scheduled(fixedRateString = "${com.jasonpyau.cache.clear-rate:#{240}}", timeUnit = TimeUnit.MINUTES)
     @CacheEvict(cacheNames = {SKILL_CACHE, SKILL_ICON_SVG_CACHE, PROJECT_CACHE, ABOUT_ME_CACHE, EXPERIENCE_CACHE}, allEntries = true)
     public void clearCache() {
-        System.out.printf("%s: Cleared Cache\n", DateFormat.MMddyyyyhhmmss());
+        System.out.printf("%s: Cleared skill, skill icon svg, project, about me, and experience caches.\n", DateFormat.MMddyyyyhhmmss());
+        System.out.printf("%s: Cleaned up unused rate limit bucket caches. New cache size: %d\n", DateFormat.MMddyyyyhhmmss(), rateLimitService.cleanCache());
     }
 }

--- a/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
+++ b/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
@@ -10,12 +10,13 @@ import org.springframework.stereotype.Component;
 public class CacheUtil {
     
     public static final String SKILL_CACHE = "skillCache";
+    public static final String SKILL_ICON_SVG_CACHE = "skillIconSvgCache";
     public static final String PROJECT_CACHE = "projectCache";
     public static final String EXPERIENCE_CACHE = "experienceCache";
     public static final String ABOUT_ME_CACHE = "aboutMeCache";
 
     @Scheduled(fixedRate = 4, timeUnit = TimeUnit.HOURS)
-    @CacheEvict(cacheNames = {SKILL_CACHE, PROJECT_CACHE, ABOUT_ME_CACHE, EXPERIENCE_CACHE}, allEntries = true)
+    @CacheEvict(cacheNames = {SKILL_CACHE, SKILL_ICON_SVG_CACHE, PROJECT_CACHE, ABOUT_ME_CACHE, EXPERIENCE_CACHE}, allEntries = true)
     public void clearCache() {
         System.out.printf("%s: Cleared Cache\n", DateFormat.MMddyyyyhhmmss());
     }

--- a/backend/src/main/java/com/jasonpyau/util/SkillIconSvgData.java
+++ b/backend/src/main/java/com/jasonpyau/util/SkillIconSvgData.java
@@ -1,0 +1,19 @@
+package com.jasonpyau.util;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SkillIconSvgData {
+
+    public static JsonNode get() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readTree(new URL("https://raw.githubusercontent.com/simple-icons/simple-icons/6.23.0/_data/simple-icons.json")).get("icons");
+        } catch (IOException e) {
+            return objectMapper.createObjectNode();
+        }
+    }
+}

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,6 +1,6 @@
 {"properties": [
   {
-    "name": "com.jasonpyau.appPassword",
+    "name": "com.jasonpyau.app-password",
     "type": "java.lang.String",
     "description": "Admin Panel password used for the Admin Panel CLI and Spring Boot server to authenticate."
   },
@@ -10,8 +10,23 @@
     "description": "Used to send email notifications after someone sends a message via the 'Contact Me' section."
   },
   {
-    "name": "com.jasonpyau.resumeLink",
+    "name": "com.jasonpyau.resume-link",
     "type": "java.lang.String",
     "description": "jasonpyau.com/resume will redirect to this link."
+  },
+  {
+    "name": "com.jasonpyau.rate-limit.tokens-per-interval",
+    "type": "java.lang.Integer",
+    "description": "Number of tokens allowed to be used per interval per user for RateLimitService.java. Default value: 600"
+  },
+  {
+    "name": "com.jasonpyau.rate-limit.interval-duration",
+    "type": "java.lang.Integer",
+    "description": "Number of seconds a user has to wait until their tokens are fully reset for RateLimitService.java. Default value: 30"
+  },
+  {
+    "name": "com.jasonpyau.cache.clear-rate",
+    "type": "java.lang.Integer",
+    "description": "How often, in minutes, to clear/clean caches for Experiences, Skills, Projects, Rate Limit, etc. Default value: 240"
   }
 ]}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -28,8 +28,13 @@ server.port=9000
 spring.profiles.active=${SPRING_ACTIVE_PROFILE}
 
 # Admin Panel password
-com.jasonpyau.appPassword=${ADMIN_PANEL_PASSWORD}
+com.jasonpyau.app-password=${ADMIN_PANEL_PASSWORD}
 # Email where you want to receive 'Contact Me' notifications
 com.jasonpyau.email=${EMAIL_NOTIFICATION_RECEIVER_ADDRESS}
 # Link to resume
-com.jasonpyau.resumeLink=${RESUME_LINK}
+com.jasonpyau.resume-link=${RESUME_LINK}
+# Rate Limit Service Configuration
+com.jasonpyau.rate-limit.tokens-per-interval=600
+com.jasonpyau.rate-limit.interval-duration=30
+# Caching for Experiences, Skills, Projects, Rate Limit, etc. Configuration
+com.jasonpyau.cache.clear-rate=240

--- a/backend/src/main/resources/static/javascript/experiences.js
+++ b/backend/src/main/resources/static/javascript/experiences.js
@@ -15,7 +15,7 @@ addEventListener('DOMContentLoaded', async(e) => {
         return;
     }
     const lastExperience = experiences[experiences.length-1];
-    const promises = experiences.map(async (experience) => {
+    experiences.map((experience) => {
         let experienceElement = document.createElement('div');
         experienceElement.innerHTML = `
             <div class="Rounded Experience my-1 py-2 border border-white" id="Experience${experience.id}">
@@ -49,6 +49,7 @@ addEventListener('DOMContentLoaded', async(e) => {
         `;
         // Replace the temp div with the div child.
         experienceElement = experienceElement.firstElementChild;
+        loadSkills(experience.skills, experienceElement.querySelector("#ExperienceSkillsContainer"));
         document.getElementById("ExperienceContainer").appendChild(experienceElement);
         if (experience !== lastExperience) {
             let verticalLine = document.createElement("div");
@@ -61,9 +62,7 @@ addEventListener('DOMContentLoaded', async(e) => {
             verticalLine = verticalLine.firstElementChild;
             document.getElementById("ExperienceContainer").appendChild(verticalLine);
         }
-        await loadSkills(experience.skills, experienceElement.querySelector("#ExperienceSkillsContainer"));
     });
-    await Promise.all(promises);
     document.getElementById("experienceSpinner").style.display = "none";
     if (window.location.hash) {
         const element = document.querySelector(window.location.hash);

--- a/backend/src/main/resources/static/javascript/experiences.js
+++ b/backend/src/main/resources/static/javascript/experiences.js
@@ -15,7 +15,7 @@ addEventListener('DOMContentLoaded', async(e) => {
         return;
     }
     const lastExperience = experiences[experiences.length-1];
-    for (const experience of experiences) {
+    const promises = experiences.map(async (experience) => {
         let experienceElement = document.createElement('div');
         experienceElement.innerHTML = `
             <div class="Rounded Experience my-1 py-2 border border-white" id="Experience${experience.id}">
@@ -49,7 +49,6 @@ addEventListener('DOMContentLoaded', async(e) => {
         `;
         // Replace the temp div with the div child.
         experienceElement = experienceElement.firstElementChild;
-        loadSkills(experience.skills, experienceElement.querySelector("#ExperienceSkillsContainer"));
         document.getElementById("ExperienceContainer").appendChild(experienceElement);
         if (experience !== lastExperience) {
             let verticalLine = document.createElement("div");
@@ -62,6 +61,14 @@ addEventListener('DOMContentLoaded', async(e) => {
             verticalLine = verticalLine.firstElementChild;
             document.getElementById("ExperienceContainer").appendChild(verticalLine);
         }
-    }
+        await loadSkills(experience.skills, experienceElement.querySelector("#ExperienceSkillsContainer"));
+    });
+    await Promise.all(promises);
     document.getElementById("experienceSpinner").style.display = "none";
+    if (window.location.hash) {
+        const element = document.querySelector(window.location.hash);
+        if (element) {
+            element.scrollIntoView({behavior: "smooth"});
+        }
+    }
 });

--- a/backend/src/main/resources/static/javascript/projects.js
+++ b/backend/src/main/resources/static/javascript/projects.js
@@ -10,7 +10,7 @@ addEventListener('DOMContentLoaded', async(e) => {
         return;
     }
     const projects = json.projects;
-    for (const project of projects) {
+    const promises = projects.map(async (project) => {
         let projectElement = document.createElement('span');
         projectElement.innerHTML = `
             <a class="Project move_when_hovered" id="Project${project.id}" href="${project.link}" target="_blank">
@@ -32,8 +32,15 @@ addEventListener('DOMContentLoaded', async(e) => {
         `;
         // Replace the temp span with the a child.
         projectElement = projectElement.firstElementChild;
-        loadSkills(project.skills, projectElement.querySelector("#SkillsContainer"));
         document.getElementById("ProjectRows").appendChild(projectElement);
-    }
+        await loadSkills(project.skills, projectElement.querySelector("#SkillsContainer"));
+    });
+    await Promise.all(promises);
     document.getElementById("projectSpinner").style.display = "none";
+    if (window.location.hash) {
+        const element = document.querySelector(window.location.hash);
+        if (element) {
+            element.scrollIntoView({behavior: "smooth"});
+        }
+    }
 });

--- a/backend/src/main/resources/static/javascript/projects.js
+++ b/backend/src/main/resources/static/javascript/projects.js
@@ -10,7 +10,7 @@ addEventListener('DOMContentLoaded', async(e) => {
         return;
     }
     const projects = json.projects;
-    const promises = projects.map(async (project) => {
+    projects.map((project) => {
         let projectElement = document.createElement('span');
         projectElement.innerHTML = `
             <a class="Project move_when_hovered" id="Project${project.id}" href="${project.link}" target="_blank">
@@ -32,10 +32,9 @@ addEventListener('DOMContentLoaded', async(e) => {
         `;
         // Replace the temp span with the a child.
         projectElement = projectElement.firstElementChild;
+        loadSkills(project.skills, projectElement.querySelector("#SkillsContainer"));
         document.getElementById("ProjectRows").appendChild(projectElement);
-        await loadSkills(project.skills, projectElement.querySelector("#SkillsContainer"));
     });
-    await Promise.all(promises);
     document.getElementById("projectSpinner").style.display = "none";
     if (window.location.hash) {
         const element = document.querySelector(window.location.hash);

--- a/backend/src/main/resources/static/javascript/skills.js
+++ b/backend/src/main/resources/static/javascript/skills.js
@@ -9,7 +9,7 @@ addEventListener('DOMContentLoaded', async(e) => {
         return;
     }
     const skillsByType = json.skills;
-    const promises = Object.keys(skillsByType).map(async (key) => {
+    Object.keys(skillsByType).map((key) => {
         const skillsRow = document.createElement('div');
         skillsRow.innerHTML = `
             <u class="fs-3 HeaderTextColor fw-bold" id="SkillType">${key}</u>
@@ -18,10 +18,9 @@ addEventListener('DOMContentLoaded', async(e) => {
             </div>
         `;
         const skillsRowContainer = skillsRow.querySelector("#SkillsRowContainer");
+        loadSkills(skillsByType[key], skillsRowContainer);
         document.getElementById("SkillsTypeRow").appendChild(skillsRow);
-        await loadSkills(skillsByType[key], skillsRowContainer);
     });
-    await Promise.all(promises);
     document.getElementById("skillSpinner").style.display = "none";
     if (window.location.hash) {
         const element = document.querySelector(window.location.hash);
@@ -31,65 +30,22 @@ addEventListener('DOMContentLoaded', async(e) => {
     }
 });
 
-async function getSimpleIconsJson() {
-    const url = "https://raw.githubusercontent.com/simple-icons/simple-icons/6.23.0/_data/simple-icons.json";
-    const result = await apiCall(url, "GET", null, null);
-    return await result.json();
-}
-
-export async function loadSkills(skills, container) {
-    const simpleIconsMap = new Map();
-    const promises = skills.map(async(skill) => {
-        await loadSkill(skill, container);
-    });
-    await Promise.all(promises);
-    for (const element of container.children) {
-        const iconElement = element.querySelector("svg");
-        // If this is true, we used simple-icons/6.23.0.
-        if (iconElement && !iconElement.getAttribute("fill")) {
-            if (!simpleIconsMap.size) {
-                const simpleIconsJson = await getSimpleIconsJson();
-                simpleIconsJson.icons.map((icon) => {
-                    simpleIconsMap.set(icon.title, `#${icon.hex}`);
-                });
-            }
-            const svgTitle = iconElement.querySelector("title").textContent;
-            iconElement.setAttribute("fill", simpleIconsMap.get(svgTitle));
-        }
+export function loadSkills(skills, container) {
+    for (const skill of skills) {
+        loadSkill(skill, container);
     }
 }
 
-async function loadSkill(skill, container) {
+function loadSkill(skill, container) {
     const element = document.createElement('span');
-    element.classList.add("d-none");
-    container.appendChild(element);
-    let iconElement = "";
-    if (skill.simpleIconsIconSlug) {
-        iconElement = await getIconElement(`https://cdn.simpleicons.org/${skill.simpleIconsIconSlug}`);
-        iconElement = iconElement || await getIconElement(`https://raw.githubusercontent.com/simple-icons/simple-icons/6.23.0/icons/${skill.simpleIconsIconSlug}.svg`);
-        if (iconElement) {
-            iconElement = new DOMParser().parseFromString(iconElement, "text/xml").firstChild;
-            iconElement.classList.add("mx-1");
-            iconElement.style.height = "16px";
-            iconElement.style.width = "16px";
-        }
-    }
     element.className = "m-1 btn btn-dark btn-sm";
     element.innerHTML = `
         <a class="text-decoration-none text-white" ${(skill.link) ? `href="${skill.link}" target="_blank"` : `href="javascript:void(0);"`}>
-            ${(iconElement) ? iconElement.outerHTML : ""}
+            ${skill.simpleIconsIconSlug ? `<img src="/skills/svg/${encodeURIComponent(skill.name)}" class="mx-1" height="16px" width="16px"/>` : ""}
             <span>
                 ${skill.name}
             </span>
         </a>
     `;
-    element.classList.remove("d-none");
-}
-
-async function getIconElement(path) {
-    const result = await apiCall(path, "GET", null, null);
-    if (result.status === 200) {
-        return await result.text();
-    }
-    return "";
+    container.appendChild(element);
 }

--- a/backend/src/main/resources/static/javascript/skills.js
+++ b/backend/src/main/resources/static/javascript/skills.js
@@ -9,7 +9,7 @@ addEventListener('DOMContentLoaded', async(e) => {
         return;
     }
     const skillsByType = json.skills;
-    Object.keys(skillsByType).forEach((key) => {
+    const promises = Object.keys(skillsByType).map(async (key) => {
         const skillsRow = document.createElement('div');
         skillsRow.innerHTML = `
             <u class="fs-3 HeaderTextColor fw-bold" id="SkillType">${key}</u>
@@ -18,10 +18,17 @@ addEventListener('DOMContentLoaded', async(e) => {
             </div>
         `;
         const skillsRowContainer = skillsRow.querySelector("#SkillsRowContainer");
-        loadSkills(skillsByType[key], skillsRowContainer);
         document.getElementById("SkillsTypeRow").appendChild(skillsRow);
-        document.getElementById("skillSpinner").style.display = "none";
+        await loadSkills(skillsByType[key], skillsRowContainer);
     });
+    await Promise.all(promises);
+    document.getElementById("skillSpinner").style.display = "none";
+    if (window.location.hash) {
+        const element = document.querySelector(window.location.hash);
+        if (element) {
+            element.scrollIntoView({behavior: "smooth"});
+        }
+    }
 });
 
 async function getSimpleIconsJson() {

--- a/backend/src/main/resources/static/javascript/skills.js
+++ b/backend/src/main/resources/static/javascript/skills.js
@@ -69,10 +69,12 @@ async function loadSkill(skill, container) {
     }
     element.className = "m-1 btn btn-dark btn-sm";
     element.innerHTML = `
-        ${(iconElement) ? iconElement.outerHTML : ""}
-        <span>
-            ${skill.name}
-        </span>
+        <a class="text-decoration-none text-white" ${(skill.link) ? `href="${skill.link}" target="_blank"` : `href="javascript:void(0);"`}>
+            ${(iconElement) ? iconElement.outerHTML : ""}
+            <span>
+                ${skill.name}
+            </span>
+        </a>
     `;
     element.classList.remove("d-none");
 }

--- a/backend/src/test/java/com/jasonpyau/service/SkillServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/SkillServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.BDDMockito.*;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.jasonpyau.entity.Skill;
 import com.jasonpyau.repository.SkillRepository;
@@ -24,17 +26,42 @@ public class SkillServiceTest {
     @InjectMocks
     private SkillService skillService;
 
-    private Skill skill = Skill.builder()
+    private Skill java = Skill.builder()
                             .id(1)
                             .name("Java")
                             .type("Language")
-                            .simpleIconsIconSlug("spring")
+                            .link("https://en.wikipedia.org/wiki/Java_(programming_language)")
+                            .simpleIconsIconSlug("java")
                             .build();
+    
+    private Skill springBoot = Skill.builder()
+                            .id(1)
+                            .name("Spring Boot")
+                            .type("Framework/Library")
+                            .link("https://en.wikipedia.org/wiki/Spring_Boot")
+                            .simpleIconsIconSlug("springboot")
+                            .build();                  
 
     @Test
     public void newSkill_SkillAlreadyExistsError() {
-        given(skillRepository.findSkillByName("Java")).willReturn(Optional.of(skill));
-        String errorMessage = skillService.newSkill(skill);
+        given(skillRepository.findSkillByName("Java")).willReturn(Optional.of(java));
+        String errorMessage = skillService.newSkill(java);
         assertEquals(Skill.SKILL_ALREADY_EXISTS_ERROR, errorMessage);
+    }
+
+    @Test
+    public void getSkillIconSvgJava() {
+        given(skillRepository.findSkillByName("Java")).willReturn(Optional.of(java));
+        String svg = skillService.getSkillIconSvg("Java");
+        assertNotEquals(svg, Skill.SKILL_ICON_EMPTY_SVG);
+        assertTrue(svg.contains("fill"));
+    }
+
+    @Test
+    public void getSkillIconSvgSpringBoot() {
+        given(skillRepository.findSkillByName("Spring Boot")).willReturn(Optional.of(springBoot));
+        String svg = skillService.getSkillIconSvg("Spring Boot");
+        assertNotEquals(svg, Skill.SKILL_ICON_EMPTY_SVG);
+        assertTrue(svg.contains("fill"));
     }
 }


### PR DESCRIPTION
- Add endpoint to update an existing skill given a skill name, updating `AdminPanel.java` to use this new endpoint
- Add endpoint to retrieve a skill icon SVG (if it exists) given a skill name, with caching enabled
- Refactor frontend code `skills.js` to use the new SVG endpoint, reducing the number of API calls made when skill icons were previously fetched from `skills.js`
- Add ability to erase existing values for optional fields in `AdminPanel.java`
- Relax `RateLimitService` rules to accommodate the increased API calls made to backend due to the new SVG endpoint
- Add properties to `application.properties` for rate limit and cache configurations and used them in `RateLimitService.java` and `CacheUtil.java`. Used hyphen-case for all self-defined properties to remove VSCode warning message
- Add funtionality in `CacheUtil.java` to clean up expired cache entries (Users that have not accessed a token in 10 minutes) in `RateLimitService.java`
- Fix scrolling to desired section in the home page on load. The previous issue was that it would scroll to the desired section initially, but then projects, skills, experiences, etc. would fully load and take up height, so the initial scroll became inaccurate