### PR TITLE
Add enum for Experience type, split Experience section to Work Experience and Education

### DIFF
--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -811,15 +811,12 @@ public class AdminPanel {
                 break;
             case "6":
                 printMessagesMenu();
-                printContinue();
                 break;
             case "7":
                 printLinksMenu();
-                printContinue();
                 break;
             case "8":
                 printMetadataMenu();
-                printContinue();
                 break;
             case "9":
                 shutDownServer();

--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -616,12 +616,17 @@ public class AdminPanel {
     private static String getExperienceBody() {
         StringBuilder sb = new StringBuilder();
         String input;
+        System.out.println("Loading valid types for an experience...");
+        apiCall("/experiences/valid_types", "{ }", "GET", false);
+        System.out.println("These are the valid types. Input the type of experience:");
+        input = scan.nextLine();
+        sb.append("{\"type\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
         System.out.println("Input experience position:");
         input = scan.nextLine();
-        sb.append("{\"position\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
-        System.out.println("Input experience company:");
+        sb.append("\"position\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
+        System.out.println("Input experience organization/company:");
         input = scan.nextLine();
-        sb.append("\"company\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
+        sb.append("\"organization\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
         System.out.println("Input experience location:");
         input = scan.nextLine();
         sb.append("\"location\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
@@ -646,9 +651,9 @@ public class AdminPanel {
         System.out.println("Input experience logo link:");
         input = scan.nextLine();
         sb.append("\"logoLink\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
-        System.out.println("Input experience company link (optional):");
+        System.out.println("Input experience organization/company link (optional):");
         input = scan.nextLine();
-        sb.append("\"companyLink\": " + ((!input.isBlank()) ? input.equals("ERASE!!!") ? "\"\"" : "\""+input+"\"" : "null") + "} ");
+        sb.append("\"organizationLink\": " + ((!input.isBlank()) ? input.equals("ERASE!!!") ? "\"\"" : "\""+input+"\"" : "null") + "} ");
         return sb.toString();
     }
 

--- a/backend/src/main/java/com/jasonpyau/advice/ValidationExceptionHandler.java
+++ b/backend/src/main/java/com/jasonpyau/advice/ValidationExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.util.Response;
 
 import jakarta.validation.ConstraintViolation;
@@ -70,7 +71,7 @@ public class ValidationExceptionHandler {
         Throwable cause = e.getCause();
         if (cause instanceof InvalidFormatException) {
             InvalidFormatException invalidFormatException = (InvalidFormatException)cause;
-            if (invalidFormatException.getTargetType().equals(Skill.Type.class)) {
+            if (invalidFormatException.getTargetType().equals(SkillType.class)) {
                 return Response.errorMessage(Skill.SKILL_TYPE_ERROR, HttpStatus.NOT_ACCEPTABLE);
             }
         }

--- a/backend/src/main/java/com/jasonpyau/advice/ValidationExceptionHandler.java
+++ b/backend/src/main/java/com/jasonpyau/advice/ValidationExceptionHandler.java
@@ -16,7 +16,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Experience.ExperienceType;
 import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.util.Response;
 
@@ -73,6 +75,8 @@ public class ValidationExceptionHandler {
             InvalidFormatException invalidFormatException = (InvalidFormatException)cause;
             if (invalidFormatException.getTargetType().equals(SkillType.class)) {
                 return Response.errorMessage(Skill.SKILL_TYPE_ERROR, HttpStatus.NOT_ACCEPTABLE);
+            } else if (invalidFormatException.getTargetType().equals(ExperienceType.class)) {
+                return Response.errorMessage(Experience.EXPERIENCE_TYPE_ERROR, HttpStatus.NOT_ACCEPTABLE);
             }
         }
         return Response.errorMessage(e.getMessage(), HttpStatus.NOT_ACCEPTABLE);

--- a/backend/src/main/java/com/jasonpyau/controller/ContactController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/ContactController.java
@@ -37,7 +37,7 @@ public class ContactController {
     @RateLimit(RateLimit.EXPENSIVE_TOKEN)
     @CrossOrigin
     public ResponseEntity<HashMap<String, Object>> sendMessage(HttpServletRequest request, @Valid @RequestBody Message message) {
-        contactService.sendMessage(message);
+        contactService.sendMessage(request, message);
         return Response.success();
     }
 

--- a/backend/src/main/java/com/jasonpyau/controller/ExperienceController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/ExperienceController.java
@@ -90,4 +90,11 @@ public class ExperienceController {
     public ResponseEntity<HashMap<String, Object>> getExperiences(HttpServletRequest request) {
         return Response.success(Response.createBody("experiences", experienceService.getExperiences()));
     }
+
+    @GetMapping(path = "/valid_types", produces = "application/json")
+    @RateLimit(RateLimit.DEFAULT_TOKEN)
+    @CrossOrigin
+    public ResponseEntity<HashMap<String, Object>> validTypes(HttpServletRequest request) {
+        return Response.success(Response.createBody("validTypes", experienceService.validTypes()));
+    }
 }

--- a/backend/src/main/java/com/jasonpyau/controller/FrontendController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/FrontendController.java
@@ -10,6 +10,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -91,7 +92,7 @@ public class FrontendController {
     @GetMapping({"/resume", "/resume/"})
     public String resume() throws IOException {
         String resumeLink = env.getProperty("com.jasonpyau.resume-link");
-        if (resumeLink != null && !resumeLink.isBlank()) {
+        if (StringUtils.hasText(resumeLink)) {
             return "redirect:"+resumeLink;
         }
         PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();

--- a/backend/src/main/java/com/jasonpyau/entity/Experience.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Experience.java
@@ -1,12 +1,16 @@
 package com.jasonpyau.entity;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import com.jasonpyau.util.DateFormat;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,31 +39,47 @@ import lombok.Setter;
 @Table(name="experiences", indexes = @Index(name = "date_order_ind", columnList = "date_order"))
 public class Experience {
 
+    public enum ExperienceType {
+        WORK_EXPERIENCE,
+        EDUCATION;
+    }
+
     public static final String EXPERIENCE_ID_ERROR = "Invalid 'id', experience not found.";
-    public static final String EXPERIENCE_POSITION_ERROR = "'position' should be between 1-30 characters.";
-    public static final String EXPERIENCE_COMPANY_ERROR = "'company' should be between 1-30 characters.";
+    public static final String EXPERIENCE_POSITION_ERROR = "'position' should be between 1-50 characters.";
+    public static final String EXPERIENCE_ORGANIZATION_ERROR = "'organization' should be between 1-50 characters.";
     public static final String EXPERIENCE_LOCATION_ERROR = "'location' should be between 1-30 characters.";
     public static final String EXPERIENCE_START_DATE_ERROR = "'startDate' should be in format 'MM/YYYY'.";
     public static final String EXPERIENCE_END_DATE_ERROR = "'endDate' should be in format 'MM/YYYY'.";
     public static final String EXPERIENCE_PRESENT_ERROR = "'present' should be true or false.";
     public static final String EXPERIENCE_BODY_ERROR = "'body' should be between 1-1000 characters.";
     public static final String EXPERIENCE_LOGO_LINK_ERROR = "'logoLink' should be between 7-500 characters and start with 'http://' or 'https://'.";
-    public static final String EXPERIENCE_COMPANY_LINK_ERROR = "'companyLink' should be between 0-250 characters and if not empty, start with 'http://' or 'https://'.";
+    public static final String EXPERIENCE_ORGANIZATION_LINK_ERROR = "'organizationLink' should be between 0-250 characters and if not empty, start with 'http://' or 'https://'.";
+    public static final String EXPERIENCE_TYPE_ERROR = "'type' should be one of the following: "+validTypes()
+                                                                                                .stream()
+                                                                                                .map(type -> String.format("'%s'", type))
+                                                                                                .toList()
+                                                                                                .toString()+".";
+    public static final String EXPERIENCE_TYPE_NULL_ERROR = "'type' should not be null.";
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id")
     private Integer id;
 
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    @NotNull(message = EXPERIENCE_TYPE_NULL_ERROR)
+    private ExperienceType type;
+
     @Column(name = "position", nullable = false)
-    @Size(min = 1, max = 30, message = EXPERIENCE_POSITION_ERROR)
+    @Size(min = 1, max = 50, message = EXPERIENCE_POSITION_ERROR)
     @NotBlank(message = EXPERIENCE_POSITION_ERROR)
     private String position;
 
-    @Column(name = "company", nullable = false)
-    @Size(min = 1, max = 30, message = EXPERIENCE_COMPANY_ERROR)
-    @NotBlank(message = EXPERIENCE_COMPANY_ERROR)
-    private String company;
+    @Column(name = "organization", nullable = false)
+    @Size(min = 1, max = 50, message = EXPERIENCE_ORGANIZATION_ERROR)
+    @NotBlank(message = EXPERIENCE_ORGANIZATION_ERROR)
+    private String organization;
 
     @Column(name = "location", nullable = false)
     @Size(min = 1, max = 30, message = EXPERIENCE_LOCATION_ERROR)
@@ -101,10 +121,10 @@ public class Experience {
     @NotBlank(message = EXPERIENCE_LOGO_LINK_ERROR)
     private String logoLink;
 
-    @Column(name = "company_link", nullable = true)
-    @Size(max = 250, message = EXPERIENCE_COMPANY_LINK_ERROR)
-    @Pattern(regexp = "^([\\s]*|(http|https):\\/\\/(.*))$", message = EXPERIENCE_COMPANY_LINK_ERROR)
-    private String companyLink;
+    @Column(name = "organization_link", nullable = true)
+    @Size(max = 250, message = EXPERIENCE_ORGANIZATION_LINK_ERROR)
+    @Pattern(regexp = "^([\\s]*|(http|https):\\/\\/(.*))$", message = EXPERIENCE_ORGANIZATION_LINK_ERROR)
+    private String organizationLink;
 
     public void createOrder() {
         String[] startSplit = this.startDate.split("/", 2);
@@ -136,5 +156,9 @@ public class Experience {
     public void deleteSkill(Skill skill) {
         skill.getExperiences().remove(this);
         this.skills.remove(skill);
+    }
+
+    public static List<String> validTypes() {
+        return Arrays.stream(ExperienceType.values()).map(ExperienceType::name).toList();
     }
 }

--- a/backend/src/main/java/com/jasonpyau/entity/Link.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Link.java
@@ -45,7 +45,7 @@ public class Link {
 
     @Column(name = "href", nullable = false)
     @Size(min = 7, max = 500, message = LINK_HREF_ERROR)
-    @Pattern(regexp = "^((http|https):\\/\\/|mailto:)(.*)$", message = LINK_HREF_ERROR)
+    @Pattern(regexp = "^((http|https):\\/\\/|mailto:|\\/)(.*)$", message = LINK_HREF_ERROR)
     @NotBlank(message = LINK_HREF_ERROR)
     private String href;
 

--- a/backend/src/main/java/com/jasonpyau/entity/Message.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Message.java
@@ -2,13 +2,17 @@ package com.jasonpyau.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,6 +20,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "messages")
@@ -48,5 +53,9 @@ public class Message {
 
     @Column(name = "date", nullable = false)
     private String date;
+
+    @JoinColumn(name = "sender_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User sender;
 
 }

--- a/backend/src/main/java/com/jasonpyau/entity/Skill.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Skill.java
@@ -1,6 +1,6 @@
 package com.jasonpyau.entity;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -122,10 +122,6 @@ public class Skill {
     private final Set<Experience> experiences = new HashSet<>();
 
     public static List<String> validTypes() {
-        ArrayList<String> validTypes = new ArrayList<>();
-        for (SkillType type : SkillType.values()) {
-            validTypes.add(type.getJsonValue());
-        }
-        return validTypes;
+        return Arrays.stream(SkillType.values()).map(SkillType::getJsonValue).collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/jasonpyau/entity/Skill.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Skill.java
@@ -43,7 +43,7 @@ import lombok.Setter;
 @Table(name = "skills", indexes = @Index(name = "type_name_ind", columnList = "type, name"))
 public class Skill {
 
-    public enum Type {
+    public enum SkillType {
         LANGUAGE("Language"),
         FRAMEWORK_OR_LIBRARY("Framework/Library"),
         DATABASE("Database"),
@@ -53,7 +53,7 @@ public class Skill {
         @JsonValue
         private final String jsonValue;
 
-        Type(String jsonValue) {
+        SkillType(String jsonValue) {
             this.jsonValue = jsonValue;
         }
     }
@@ -84,7 +84,7 @@ public class Skill {
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
     @NotNull(message = SKILL_TYPE_NULL_ERROR)
-    private Type type;
+    private SkillType type;
 
     @Column(name = "link", nullable = true)
     @Size(max = 250, message = SKILL_LINK_ERROR)
@@ -123,7 +123,7 @@ public class Skill {
 
     public static List<String> validTypes() {
         ArrayList<String> validTypes = new ArrayList<>();
-        for (Type type : Type.values()) {
+        for (SkillType type : SkillType.values()) {
             validTypes.add(type.getJsonValue());
         }
         return validTypes;

--- a/backend/src/main/java/com/jasonpyau/entity/User.java
+++ b/backend/src/main/java/com/jasonpyau/entity/User.java
@@ -3,6 +3,9 @@ package com.jasonpyau.entity;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,8 +13,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -19,6 +24,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "users")
@@ -34,7 +40,14 @@ public class User {
     
     @Column(name = "liked_blogs")
     @ManyToMany(mappedBy = "likedUsers", fetch = FetchType.LAZY)
-    private Set<Blog> likedBlogs = new HashSet<>();
+    @JsonIgnore
+    private final Set<Blog> likedBlogs = new HashSet<>();
+
+    @Column(name = "messages")
+    @OneToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "sender")
+    @JsonIgnore
+    private final Set<Message> messages = new HashSet<>();
+
 
     @Override
     public boolean equals(Object o) {

--- a/backend/src/main/java/com/jasonpyau/repository/ContactRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/ContactRepository.java
@@ -10,6 +10,6 @@ import com.jasonpyau.entity.Message;
 
 @Repository
 public interface ContactRepository extends JpaRepository<Message, Long> {
-    @Query(value = "SELECT * FROM messages ORDER BY date DESC", nativeQuery = true)
-    public Page<Message> findAllWithPaginationOrderedByDate(Pageable pageable);
+    @Query(value = "SELECT m from Message m LEFT JOIN FETCH m.sender ORDER BY date DESC", nativeQuery = false)
+    public Page<Message> findAllJoinedWithSenderWithPaginationOrderedByDate(Pageable pageable);
 }

--- a/backend/src/main/java/com/jasonpyau/repository/ExperienceRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/ExperienceRepository.java
@@ -4,12 +4,13 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Experience;
 
 @Repository
 public interface ExperienceRepository extends JpaRepository<Experience, Integer> {
-    @Query(value = "SELECT * FROM experiences ORDER BY date_order DESC", nativeQuery = true)
-    public List<Experience> findAllByDate();
+    @Query(value = "SELECT * FROM experiences WHERE type = :type ORDER BY date_order DESC", nativeQuery = true)
+    public List<Experience> findAllByTypeNameOrderedByDate(@Param("type") String type);
 }

--- a/backend/src/main/java/com/jasonpyau/repository/LinkRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/LinkRepository.java
@@ -11,5 +11,5 @@ import com.jasonpyau.entity.Link;
 @Repository
 public interface LinkRepository extends JpaRepository<Link, Integer> {
     @Query(value = "SELECT * from links ORDER BY last_updated_unix_time DESC", nativeQuery = true)
-    public List<Link> findAllByLastUpdatedUnixTime();
+    public List<Link> findAllOrderedByLastUpdatedUnixTime();
 }

--- a/backend/src/main/java/com/jasonpyau/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/ProjectRepository.java
@@ -11,5 +11,5 @@ import com.jasonpyau.entity.Project;
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Integer> {
     @Query(value = "SELECT * FROM projects ORDER BY date_order DESC", nativeQuery = true)
-    public List<Project> findAllByDate();
+    public List<Project> findAllOrderedByDate();
 }

--- a/backend/src/main/java/com/jasonpyau/repository/SkillRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/SkillRepository.java
@@ -13,7 +13,7 @@ import com.jasonpyau.entity.Skill;
 @Repository
 public interface SkillRepository extends JpaRepository<Skill, Integer> {
     @Query(value = "SELECT * FROM skills WHERE type = :type ORDER BY name ASC", nativeQuery = true)
-    public List<Skill> findAllSkillsByTypeName(@Param("type") String type);
+    public List<Skill> findAllByTypeNameOrderedByName(@Param("type") String type);
     @Query(value = "SELECT * FROM skills WHERE name = :name", nativeQuery = true)
-    public Optional<Skill> findSkillByName(@Param("name") String name);
+    public Optional<Skill> findByName(@Param("name") String name);
 }

--- a/backend/src/main/java/com/jasonpyau/repository/UserRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/UserRepository.java
@@ -12,5 +12,5 @@ import com.jasonpyau.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "SELECT * FROM users WHERE address = :address", nativeQuery = true)
-    public Optional<User> findUserByAddress(@Param("address") String address);
+    public Optional<User> findByAddress(@Param("address") String address);
 }

--- a/backend/src/main/java/com/jasonpyau/service/AuthorizationService.java
+++ b/backend/src/main/java/com/jasonpyau/service/AuthorizationService.java
@@ -2,6 +2,7 @@ package com.jasonpyau.service;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -23,6 +24,6 @@ public class AuthorizationService {
             return false;
         }
         String password = request.getHeader("Authorization");
-        return (password != null && !password.isBlank() && password.equals(appPassword));
+        return (StringUtils.hasText(password) && password.equals(appPassword));
     }
 }

--- a/backend/src/main/java/com/jasonpyau/service/ContactService.java
+++ b/backend/src/main/java/com/jasonpyau/service/ContactService.java
@@ -14,6 +14,8 @@ import com.jasonpyau.form.PaginationForm;
 import com.jasonpyau.repository.ContactRepository;
 import com.jasonpyau.util.DateFormat;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 @Service
 public class ContactService {
     
@@ -21,12 +23,15 @@ public class ContactService {
     private ContactRepository contactRepository;
     @Autowired
     private EmailService emailService;
+    @Autowired
+    private UserService userService;
 
-    public void sendMessage(Message message) {
+    public void sendMessage(HttpServletRequest request, Message message) {
         String name = message.getName();
         String contactInfo = message.getContactInfo();
         String body = message.getBody();
         message.setDate(DateFormat.yyyyMMddHHmmss());
+        message.setSender(userService.getUser(request));
         contactRepository.save(message);
         String emailSubject = name + " sent you a message";
         String emailBody = "Name: " + name + "\n" +
@@ -37,7 +42,7 @@ public class ContactService {
 
     public Page<Message> getMessages(PaginationForm paginationForm) {
         Pageable pageable = PageRequest.of(paginationForm.getPageNum(), paginationForm.getPageSize());
-        Page<Message> page = contactRepository.findAllWithPaginationOrderedByDate(pageable);
+        Page<Message> page = contactRepository.findAllJoinedWithSenderWithPaginationOrderedByDate(pageable);
         return page;
     }
 

--- a/backend/src/main/java/com/jasonpyau/service/LinkService.java
+++ b/backend/src/main/java/com/jasonpyau/service/LinkService.java
@@ -70,7 +70,7 @@ public class LinkService {
 
     @Cacheable(cacheNames = CacheUtil.LINK_CACHE)
     public List<Link> getLinks() {
-        return linkRepository.findAllByLastUpdatedUnixTime();
+        return linkRepository.findAllOrderedByLastUpdatedUnixTime();
     }
 
     @Cacheable(cacheNames = CacheUtil.LINK_CACHE)

--- a/backend/src/main/java/com/jasonpyau/service/LinkService.java
+++ b/backend/src/main/java/com/jasonpyau/service/LinkService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import com.jasonpyau.entity.Link;
 import com.jasonpyau.exception.ResourceNotFoundException;
@@ -80,11 +81,11 @@ public class LinkService {
             return SimpleIconsService.EMPTY_SVG;
         }
         Link link = optional.get();
-        if (link.getSimpleIconsIconSlug() == null || link.getSimpleIconsIconSlug().isBlank()) {
+        if (!StringUtils.hasText(link.getSimpleIconsIconSlug())) {
             return SimpleIconsService.EMPTY_SVG;
         }
         String svg = simpleIconsService.getSimpleIconsSvg(link.getSimpleIconsIconSlug());
-        if (link.getHexFill() != null && !link.getHexFill().isBlank() && !svg.equals(SimpleIconsService.EMPTY_SVG)) {
+        if (StringUtils.hasText(link.getHexFill()) && !svg.equals(SimpleIconsService.EMPTY_SVG)) {
             svg = simpleIconsService.replaceSvgFill(svg, link.getHexFill());
         }
         return svg;

--- a/backend/src/main/java/com/jasonpyau/service/ProjectService.java
+++ b/backend/src/main/java/com/jasonpyau/service/ProjectService.java
@@ -77,7 +77,7 @@ public class ProjectService {
 
     @Cacheable(cacheNames = CacheUtil.PROJECT_CACHE)
     public List<Project> getProjects() {
-        return projectRepository.findAllByDate();
+        return projectRepository.findAllOrderedByDate();
     }
 
     @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)

--- a/backend/src/main/java/com/jasonpyau/service/SimpleIconsService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SimpleIconsService.java
@@ -24,7 +24,7 @@ public class SimpleIconsService {
 
     public static final String EMPTY_SVG = "";
     
-    public final JsonNode v6_23_0IconsData = getV6_23_0IconsData();
+    private final JsonNode v6_23_0IconsData = getV6_23_0IconsData();
 
     private JsonNode getV6_23_0IconsData() {
         ObjectMapper objectMapper = new ObjectMapper();

--- a/backend/src/main/java/com/jasonpyau/service/SimpleIconsService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SimpleIconsService.java
@@ -12,6 +12,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -37,7 +38,7 @@ public class SimpleIconsService {
 
     @Cacheable(cacheNames = CacheUtil.SIMPLE_ICONS_SVG_CACHE)
     public String getSimpleIconsSvg(String simpleIconsIconSlug) {
-        if (simpleIconsIconSlug == null || simpleIconsIconSlug.isBlank()) {
+        if (!StringUtils.hasText(simpleIconsIconSlug)) {
             return EMPTY_SVG;
         }
         RestClient restClient = RestClient.create();

--- a/backend/src/main/java/com/jasonpyau/service/SkillService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SkillService.java
@@ -36,7 +36,7 @@ public class SkillService {
 
     @CacheEvict(cacheNames = {CacheUtil.SKILL_CACHE}, allEntries = true)
     public void newSkill(Skill skill) {
-        if (skillRepository.findSkillByName(skill.getName()).isPresent()) {
+        if (skillRepository.findByName(skill.getName()).isPresent()) {
             throw new ResourceAlreadyExistsException(Skill.SKILL_ALREADY_EXISTS_ERROR);
         }
         skillRepository.save(skill);
@@ -44,7 +44,7 @@ public class SkillService {
 
     @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.EXPERIENCE_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
     public void updateSkill(Skill updateSkill) {
-        Optional<Skill> optional = skillRepository.findSkillByName(updateSkill.getName());
+        Optional<Skill> optional = skillRepository.findByName(updateSkill.getName());
         if (!optional.isPresent()) {
             throw new ResourceNotFoundException(Skill.SKILL_NOT_FOUND_ERROR);
         }
@@ -59,7 +59,7 @@ public class SkillService {
 
     @CacheEvict(cacheNames = {CacheUtil.PROJECT_CACHE, CacheUtil.EXPERIENCE_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
     public void deleteSkill(String skillName) {
-        Optional<Skill> optional = skillRepository.findSkillByName(skillName);
+        Optional<Skill> optional = skillRepository.findByName(skillName);
         if (!optional.isPresent()) {
             throw new ResourceNotFoundException(Skill.SKILL_NOT_FOUND_ERROR);
         }
@@ -70,14 +70,14 @@ public class SkillService {
     public HashMap<String, List<Skill>> getSkills() {
         HashMap<String, List<Skill>> res = new HashMap<>();
         for (SkillType type : SkillType.values()) {
-            res.put(type.getJsonValue(), skillRepository.findAllSkillsByTypeName(type.name()));
+            res.put(type.getJsonValue(), skillRepository.findAllByTypeNameOrderedByName(type.name()));
         }
         return res;
     }
 
     @Cacheable(cacheNames = CacheUtil.SKILL_CACHE)
     public String getSkillIconSvg(String skillName) {
-        Optional<Skill> optional = skillRepository.findSkillByName(skillName);
+        Optional<Skill> optional = skillRepository.findByName(skillName);
         if (!optional.isPresent()) {
             return SimpleIconsService.EMPTY_SVG;
         }
@@ -97,7 +97,7 @@ public class SkillService {
     }
 
     public Optional<Skill> getSkillByName(String skillName) {
-        return skillRepository.findSkillByName(skillName);
+        return skillRepository.findByName(skillName);
     }
 
 }

--- a/backend/src/main/java/com/jasonpyau/service/SkillService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SkillService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import com.jasonpyau.entity.Skill;
 import com.jasonpyau.entity.Skill.SkillType;
@@ -82,11 +83,11 @@ public class SkillService {
             return SimpleIconsService.EMPTY_SVG;
         }
         Skill skill = optional.get();
-        if (skill.getSimpleIconsIconSlug() == null || skill.getSimpleIconsIconSlug().isBlank()) {
+        if (!StringUtils.hasText(skillName)) {
             return SimpleIconsService.EMPTY_SVG;
         }
         String svg = simpleIconsService.getSimpleIconsSvg(skill.getSimpleIconsIconSlug());
-        if (skill.getHexFill() != null && !skill.getHexFill().isBlank() && !svg.equals(SimpleIconsService.EMPTY_SVG)) {
+        if (StringUtils.hasText(skill.getHexFill()) && !svg.equals(SimpleIconsService.EMPTY_SVG)) {
             svg = simpleIconsService.replaceSvgFill(svg, skill.getHexFill());
         }
         return svg;

--- a/backend/src/main/java/com/jasonpyau/service/SkillService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SkillService.java
@@ -11,6 +11,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.exception.ResourceAlreadyExistsException;
 import com.jasonpyau.exception.ResourceNotFoundException;
 import com.jasonpyau.repository.SkillRepository;
@@ -68,7 +69,7 @@ public class SkillService {
     @Cacheable(cacheNames = CacheUtil.SKILL_CACHE)
     public HashMap<String, List<Skill>> getSkills() {
         HashMap<String, List<Skill>> res = new HashMap<>();
-        for (Skill.Type type : Skill.Type.values()) {
+        for (SkillType type : SkillType.values()) {
             res.put(type.getJsonValue(), skillRepository.findAllSkillsByTypeName(type.name()));
         }
         return res;

--- a/backend/src/main/java/com/jasonpyau/service/UserService.java
+++ b/backend/src/main/java/com/jasonpyau/service/UserService.java
@@ -26,6 +26,7 @@ public class UserService {
         this.activeProfile = activeProfile;
     }
 
+    // Use if you want to get the user without querying the database and creating a new user (if the user doesn't exist).
     public User getDummyUser(HttpServletRequest request) {
         String hashedAddress = getUserAddress(request);
         User user = new User();
@@ -41,7 +42,7 @@ public class UserService {
         } else {
             User user = new User();
             user.setAddress(hashedAddress);
-            return user;
+            return userRepository.save(user);
         }
     }
 

--- a/backend/src/main/java/com/jasonpyau/service/UserService.java
+++ b/backend/src/main/java/com/jasonpyau/service/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
 
     public User getUser(HttpServletRequest request) {
         String hashedAddress = getUserAddress(request);
-        Optional<User> optional = userRepository.findUserByAddress(hashedAddress);
+        Optional<User> optional = userRepository.findByAddress(hashedAddress);
         if (optional.isPresent()) {
             return optional.get();
         } else {

--- a/backend/src/main/resources/static/javascript/ContactForm.js
+++ b/backend/src/main/resources/static/javascript/ContactForm.js
@@ -15,19 +15,19 @@ async function contactFormSubmit() {
         contactInfo: contactInfo,
         body: message
     };
+    const contactFormSuccessElement = document.getElementById("ContactFormSuccess");
+    const contactFormErrorElement = document.getElementById("ContactFormError");
+    contactFormSuccessElement.style.display = "none";
+    contactFormErrorElement.style.display = "none";
     document.getElementById("ContactMeSendButton").classList.add("disabled");
     document.getElementById("ContactMeSpinner").style.display = "block";
     const result = await apiCall(url, "POST", headers, body);
     const json = await result.json();
     document.getElementById("ContactMeSendButton").classList.remove("disabled");
     document.getElementById("ContactMeSpinner").style.display = "none";
-    const contactFormSuccessElement = document.getElementById("ContactFormSuccess");
-    const contactFormErrorElement = document.getElementById("ContactFormError");
     if (result.status === 200) {
         contactFormSuccessElement.style.display = "flex";
-        contactFormErrorElement.style.display = "none";
     } else {
-        contactFormSuccessElement.style.display = "none";
         contactFormErrorElement.style.display = "flex";
         contactFormErrorElement.textContent = json.reason;
         if (result.status !== 406) {

--- a/backend/src/main/resources/static/javascript/experiences.js
+++ b/backend/src/main/resources/static/javascript/experiences.js
@@ -49,10 +49,12 @@ function loadExperiences(experiences, type) {
                                 `}
                                 <span class="fw-semibold" id="Location">- ${experience.location}</span>   
                             </div>
-                            <div class="fs-6 my-1 fw-semibold fst-italic" id="DateContainer">
+                            <div class="fs-6 my-1 fw-semibold" id="DateContainer">
                                 <span id="StartDate">${experience.startDate}</span>
                                 <span>-</span>
                                 <span id="EndDate">${experience.present ? "Present" : experience.endDate}</span>
+                                <span>·</span>
+                                <span class="fst-italic" id="TimeElasped">${getYrsAndMos(experience.startDate, experience.endDate)}</span>
                             </div>
                             <div class="fs-6 my-4 fw-semibold me-3" id="Body">
                                 ${experience.body}
@@ -79,7 +81,7 @@ function loadExperiences(experiences, type) {
                             <div class="fs-5 my-1">
                                 ${experience.position}
                             </div>
-                            <div class="fs-6 my-1 fw-semibold fst-italic" id="DateContainer">
+                            <div class="fs-6 my-1 fw-semibold" id="DateContainer">
                                 <span id="StartDate">${experience.startDate}</span>
                                 <span>-</span>
                                 <span id="EndDate">${experience.present ? "Present" : experience.endDate}</span>
@@ -112,4 +114,23 @@ function loadExperiences(experiences, type) {
         }
     });
     spinner.style.display = "none";
+}
+
+function getYrsAndMos(startDate, endDate) {
+    const startMonth = +startDate.substring(0, 2), startYear = +startDate.substring(3);
+    const endMonth = +endDate.substring(0, 2), endYear = +endDate.substring(3);
+    // If startDate = endDate, diffInMonths = 1.
+    const diffInMonths = (endYear-startYear)*12+(endMonth-startMonth)+1;
+    const years = Math.floor(diffInMonths/12), months = diffInMonths%12;
+    if (years > 0) {
+        if (months > 0) {
+            return `${years} yr${years === 1 ? '' : 's'} ${months} mo${months === 1 ? '' : 's'}`;
+        } else {
+            return `${years} yr${years === 1 ? '' : 's'}`;
+        }
+    } else if (months > 0) {
+        return `${months} mo${months === 1 ? '' : 's'}`;
+    } else {
+        return "0 mos";
+    }
 }

--- a/backend/src/main/resources/static/javascript/experiences.js
+++ b/backend/src/main/resources/static/javascript/experiences.js
@@ -25,10 +25,10 @@ addEventListener('DOMContentLoaded', async(e) => {
                 <div class="d-flex mx-4">
                     <div class="w-100 mx-2">
                         <div class="fs-5 my-2">
-                            ${experience.companyLink ? `
-                                <a class="fw-bold text-decoration-underline text-white" id="Company" href="${experience.companyLink}" target="_blank">${experience.company}</a>
+                            ${experience.organizationLink ? `
+                                <a class="fw-bold text-decoration-underline text-white" id="Organization" href="${experience.organizationLink}" target="_blank">${experience.organization}</a>
                                 `:`
-                                <span class="fw-bold text-decoration-underline" id="Company">${experience.company}</span>
+                                <span class="fw-bold text-decoration-underline" id="Organization">${experience.organization}</span>
                             `}
                             <span class="fw-semibold" id="Location">- ${experience.location}</span>   
                         </div>

--- a/backend/src/main/resources/static/javascript/experiences.js
+++ b/backend/src/main/resources/static/javascript/experiences.js
@@ -9,48 +9,96 @@ addEventListener('DOMContentLoaded', async(e) => {
         alert(`Error in loading experiences, refresh. If this problem persists, contact me.\n\nReason: ${json.reason}`);
         return;
     }
-    const experiences = json.experiences;
+    const experiencesByType = json.experiences;
+    Object.keys(experiencesByType).map((type) => {
+        loadExperiences(experiencesByType[type], type);
+    });
+    if (window.location.hash) {
+        const element = document.querySelector(window.location.hash);
+        if (element) {
+            element.scrollIntoView({behavior: "smooth"});
+        }
+    }
+});
+
+function loadExperiences(experiences, type) {
+    const spinnerId = (type === "WORK_EXPERIENCE") ? "experienceSpinner" : "educationSpinner";
+    const containerId = (type === "WORK_EXPERIENCE") ? "ExperienceContainer" : "EducationContainer";
+    const spinner = document.getElementById(spinnerId);
+    const container = document.getElementById(containerId);
     if (!experiences.length) {
-        document.getElementById("experienceSpinner").style.display = "none";
+        spinner.style.display = "none";
         return;
     }
     const lastExperience = experiences[experiences.length-1];
     experiences.map((experience) => {
         let experienceElement = document.createElement('div');
-        experienceElement.innerHTML = `
-            <div class="Rounded Experience my-1 py-2 border border-white" id="Experience${experience.id}">
-                <div class="fs-3 fw-bold mx-4 my-2 text-decoration-underline" id="Position">
-                    ${experience.position}
-                </div>
-                <div class="d-flex mx-4">
-                    <div class="w-100 mx-2">
-                        <div class="fs-5 my-2">
-                            ${experience.organizationLink ? `
-                                <a class="fw-bold text-decoration-underline text-white" id="Organization" href="${experience.organizationLink}" target="_blank">${experience.organization}</a>
-                                `:`
-                                <span class="fw-bold text-decoration-underline" id="Organization">${experience.organization}</span>
-                            `}
-                            <span class="fw-semibold" id="Location">- ${experience.location}</span>   
-                        </div>
-                        <div class="fs-6 my-2 fw-semibold fst-italic" id="DateContainer">
-                            <span id="StartDate">${experience.startDate}</span>
-                            <span>-</span>
-                            <span id="EndDate">${experience.present ? "Present" : experience.endDate}</span>
-                        </div>
-                        <div class="fs-6 my-4 fw-semibold me-3" id="Body">
-                            ${experience.body}
-                        </div>
-                        <div class="my-3" id="ExperienceSkillsContainer">
-                        </div>
+        if (type === "WORK_EXPERIENCE") {
+            experienceElement.innerHTML = `
+                <div class="Rounded Experience my-1 py-2 border border-white" id="Experience${experience.id}">
+                    <div class="fs-3 fw-bold mx-4 my-2 text-decoration-underline" id="Position">
+                        ${experience.position}
                     </div>
-                    <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}"/>
+                    <div class="d-flex mx-4">
+                        <div class="w-100 mx-2">
+                            <div class="fs-5 my-1">
+                                ${experience.organizationLink ? `
+                                    <a class="fw-bold text-decoration-underline text-white opaque_when_hovered" id="Organization" href="${experience.organizationLink}" target="_blank">${experience.organization}</a>
+                                    `:`
+                                    <span class="fw-bold text-decoration-underline" id="Organization">${experience.organization}</span>
+                                `}
+                                <span class="fw-semibold" id="Location">- ${experience.location}</span>   
+                            </div>
+                            <div class="fs-6 my-1 fw-semibold fst-italic" id="DateContainer">
+                                <span id="StartDate">${experience.startDate}</span>
+                                <span>-</span>
+                                <span id="EndDate">${experience.present ? "Present" : experience.endDate}</span>
+                            </div>
+                            <div class="fs-6 my-4 fw-semibold me-3" id="Body">
+                                ${experience.body}
+                            </div>
+                            <div class="my-3" id="ExperienceSkillsContainer">
+                            </div>
+                        </div>
+                        <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}"/>
+                    </div>
                 </div>
-            </div>
-        `;
+            `;
+        } else if (type === "EDUCATION") {
+            experienceElement.innerHTML = `
+                <div class="Rounded Experience my-1 py-2 border border-white" id="Experience${experience.id}">
+                    <div class="fs-3 fw-bold mx-4 my-2 text-decoration-underline" title="${experience.location}">
+                        ${experience.organizationLink ? `
+                            <a class="text-white opaque_when_hovered" id="Organization" href="${experience.organizationLink}" target="_blank">${experience.organization}</a>
+                            `:`
+                            <span id="Organization">${experience.organization}</span>
+                        `}
+                    </div>
+                    <div class="d-flex mx-4">
+                        <div class="w-100 mx-2">
+                            <div class="fs-5 my-1">
+                                ${experience.position}
+                            </div>
+                            <div class="fs-6 my-1 fw-semibold fst-italic" id="DateContainer">
+                                <span id="StartDate">${experience.startDate}</span>
+                                <span>-</span>
+                                <span id="EndDate">${experience.present ? "Present" : experience.endDate}</span>
+                            </div>
+                            <div class="fs-6 my-4 fw-semibold me-3" id="Body">
+                                ${experience.body}
+                            </div>
+                            <div class="my-3" id="ExperienceSkillsContainer">
+                            </div>
+                        </div>
+                        <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}"/>
+                    </div>
+                </div>
+            `;
+        }
         // Replace the temp div with the div child.
         experienceElement = experienceElement.firstElementChild;
         loadSkills(experience.skills, experienceElement.querySelector("#ExperienceSkillsContainer"));
-        document.getElementById("ExperienceContainer").appendChild(experienceElement);
+        container.appendChild(experienceElement);
         if (experience !== lastExperience) {
             let verticalLine = document.createElement("div");
             verticalLine.innerHTML = `
@@ -60,14 +108,8 @@ addEventListener('DOMContentLoaded', async(e) => {
             `;
             // Replace the temp div with the div child.
             verticalLine = verticalLine.firstElementChild;
-            document.getElementById("ExperienceContainer").appendChild(verticalLine);
+            container.appendChild(verticalLine);
         }
     });
-    document.getElementById("experienceSpinner").style.display = "none";
-    if (window.location.hash) {
-        const element = document.querySelector(window.location.hash);
-        if (element) {
-            element.scrollIntoView({behavior: "smooth"});
-        }
-    }
-});
+    spinner.style.display = "none";
+}

--- a/backend/src/main/resources/static/javascript/skills.js
+++ b/backend/src/main/resources/static/javascript/skills.js
@@ -9,16 +9,16 @@ addEventListener('DOMContentLoaded', async(e) => {
         return;
     }
     const skillsByType = json.skills;
-    Object.keys(skillsByType).map((key) => {
+    Object.keys(skillsByType).map((type) => {
         const skillsRow = document.createElement('div');
         skillsRow.innerHTML = `
-            <u class="fs-3 HeaderTextColor fw-bold" id="SkillType">${key}</u>
+            <u class="fs-3 HeaderTextColor fw-bold" id="SkillType">${type}</u>
             <div class="Rounded my-3 py-2 SkillsRowContainer" id="SkillsRowContainer">
 
             </div>
         `;
         const skillsRowContainer = skillsRow.querySelector("#SkillsRowContainer");
-        loadSkills(skillsByType[key], skillsRowContainer);
+        loadSkills(skillsByType[type], skillsRowContainer);
         document.getElementById("SkillsTypeRow").appendChild(skillsRow);
     });
     document.getElementById("skillSpinner").style.display = "none";

--- a/backend/src/main/resources/templates/index.html
+++ b/backend/src/main/resources/templates/index.html
@@ -32,8 +32,8 @@
                 </div>
             </div>
 
-            <br id="Experiences"><br><br>
-            <u class="display-5 d-flex justify-content-center HeaderTextColor fw-bold">Experiences</u>
+            <br id="Experience"><br><br>
+            <u class="display-5 d-flex justify-content-center HeaderTextColor fw-bold">Experience</u>
             <div class="container-xxl ThemeToSecondaryGradient Rounded my-3 py-3" id="ExperienceContainer">
                 <div class="text-center">
                     <div class="spinner-border" id="experienceSpinner" role="status"></div>
@@ -57,6 +57,15 @@
                 <div id="SkillsTypeRow">
                     
                 </div>
+            </div>
+
+            <br id="Education"><br><br>
+            <u class="display-5 d-flex justify-content-center HeaderTextColor fw-bold">Education</u>
+            <div class="container-xxl ThemeToSecondaryGradient Rounded my-3 py-3" id="EducationContainer">
+                <div class="text-center">
+                    <div class="spinner-border" id="educationSpinner" role="status"></div>
+                </div>
+                
             </div>
 
             <br id="Contact"><br><br>

--- a/backend/src/main/resources/templates/template.html
+++ b/backend/src/main/resources/templates/template.html
@@ -32,15 +32,16 @@
               <div class="collapse navbar-collapse" id="navbarNavDropdown">
                 <ul class="navbar-nav">
                   <li class="my-auto mx-2 nav-item dropdown">
-                    <a class="fs-4 fw-semibold nav-link dropdown-toggle" href="/#" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="Home" id="nav-link-home">
+                    <a class="fs-4 fw-semibold nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="Home" id="nav-link-home">
                       Home
                     </a>
                     <ul class="dropdown-menu">
-                      <li><a class="dropdown-item" href="/#AboutMe" title="About Me">About Me</a></li>
-                      <li><a class="dropdown-item" href="/#Experiences" title="Experiences">Experiences</a></li>
-                      <li><a class="dropdown-item" href="/#Projects" title="Projects">Projects</a></li>
-                      <li><a class="dropdown-item" href="/#Skills" title="Skills">Skills</a></li>
-                      <li><a class="dropdown-item" href="/#Contact" title="Contact Me">Contact Me</a></li>
+                      <li><a class="dropdown-item" href="/#AboutMe" onclick="scrollToHeader('AboutMe')" title="About Me">About Me</a></li>
+                      <li><a class="dropdown-item" href="/#Experience" onclick="scrollToHeader('Experience')" title="Experience">Experience</a></li>
+                      <li><a class="dropdown-item" href="/#Projects" onclick="scrollToHeader('Projects')" title="Projects">Projects</a></li>
+                      <li><a class="dropdown-item" href="/#Skills" onclick="scrollToHeader('Skills')" title="Skills">Skills</a></li>
+                      <li><a class="dropdown-item" href="/#Education" onclick="scrollToHeader('Education')" title="Skills">Education</a></li>
+                      <li><a class="dropdown-item" href="/#Contact" onclick="scrollToHeader('Contact')" title="Contact Me">Contact Me</a></li>
                     </ul>
                   </li>
                   <li class="my-auto mx-2 nav-item">
@@ -114,6 +115,14 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
         <script src="/javascript/apiCall.js" type="module"></script>
         <script src="/javascript/repoStats.js" type="module"></script>
+        <script>
+            // This script guarantees that the header is scrolled to.
+            window.scrollToHeader = function(headerId) {
+                if (document.getElementById(headerId)) {
+                    document.getElementById(headerId).scrollIntoView({behavior: 'smooth'});
+                }
+            }
+        </script>
     </th:block>
 
 </body>

--- a/backend/src/test/java/com/jasonpyau/controller/ContactControllerTest.java
+++ b/backend/src/test/java/com/jasonpyau/controller/ContactControllerTest.java
@@ -3,6 +3,7 @@ package com.jasonpyau.controller;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -13,7 +14,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jasonpyau.entity.Message;
 import com.jasonpyau.service.ContactService;
-import com.jasonpyau.util.DateFormat;
 
 @WebMvcTest(ContactController.class)
 public class ContactControllerTest {
@@ -27,7 +27,19 @@ public class ContactControllerTest {
     @MockBean
     private ContactService contactService;
 
-    private Message message1 = new Message(1L, "Message1", "test1@gmail.com", "This is a test body of Message1", DateFormat.yyyyMMddHHmmss());
+    private Message message;
+
+    @BeforeEach
+    public void setUp() {
+        this.message = Message.builder()
+        .id(1L)
+        .name("Jason Yau")
+        .contactInfo("test@jasonpyau.com")
+        .body("This is a test body of the message!")
+        .date(null)
+        .sender(null)
+        .build();
+    }
 
     @Test
     public void testSendMessage() throws Exception {
@@ -35,14 +47,14 @@ public class ContactControllerTest {
             .header("X-Forwarded-For", "localhost")
             .header("CF-Connecting-IP", "localhost")
             .contentType("application/json")
-            .content(objectMapper.writeValueAsString(message1)))
+            .content(objectMapper.writeValueAsString(message)))
             .andExpect(status().isOk());
     }
 
     @Test
     public void testSendMessage_MessageNameError() throws Exception {
         String invalidName = "a".repeat(100);
-        Message message = new Message(2L, invalidName, "test3@gmail.com", "This is a test body of MessageTest", null);
+        message.setName(invalidName);
         mockMvc.perform(MockMvcRequestBuilders.post("/contact/send")
             .header("X-Forwarded-For", "localhost")
             .header("CF-Connecting-IP", "localhost")
@@ -55,7 +67,7 @@ public class ContactControllerTest {
     @Test
     public void testSendMessage_MessageBodyError() throws Exception {
         String invalidBody = "";
-        Message message = new Message(3L, "MessageTest", "test3@gmail.com", invalidBody, null);
+        message.setBody(invalidBody);
         mockMvc.perform(MockMvcRequestBuilders.post("/contact/send")
             .header("X-Forwarded-For", "localhost")
             .header("CF-Connecting-IP", "localhost")
@@ -69,7 +81,8 @@ public class ContactControllerTest {
     public void testSendMessage_MessageNameError_MessageBodyError() throws Exception {
         String invalidName = "a".repeat(100);
         String invalidBody = "";
-        Message message = new Message(3L, invalidName, "test3@gmail.com", invalidBody, null);
+        message.setName(invalidName);
+        message.setBody(invalidBody);
         mockMvc.perform(MockMvcRequestBuilders.post("/contact/send")
             .header("X-Forwarded-For", "localhost")
             .header("CF-Connecting-IP", "localhost")

--- a/backend/src/test/java/com/jasonpyau/controller/ExperienceControllerTest.java
+++ b/backend/src/test/java/com/jasonpyau/controller/ExperienceControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.repository.ExperienceRepository;
 import com.jasonpyau.service.ExperienceService;
 
@@ -48,7 +49,7 @@ public class ExperienceControllerTest {
     private Skill skill = Skill.builder()
                             .id(1)
                             .name("Java")
-                            .type(Skill.Type.LANGUAGE)
+                            .type(SkillType.LANGUAGE)
                             .link("https://en.wikipedia.org/wiki/Java_(programming_language)")
                             .simpleIconsIconSlug("spring")
                             .hexFill("#ffffff")

--- a/backend/src/test/java/com/jasonpyau/controller/ExperienceControllerTest.java
+++ b/backend/src/test/java/com/jasonpyau/controller/ExperienceControllerTest.java
@@ -4,8 +4,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +17,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Experience.ExperienceType;
 import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.repository.ExperienceRepository;
 import com.jasonpyau.service.ExperienceService;
@@ -36,14 +36,14 @@ public class ExperienceControllerTest {
     private Experience experience = Experience.builder()
                                         .id(1)
                                         .position("Software Engineer Intern")
-                                        .company("Meta")
+                                        .organization("Meta")
                                         .location("Menlo Park, CA")
                                         .startDate("05/2024")
                                         .endDate("08/2024")
                                         .present(false)
                                         .body("Software Engineer Intern working on engineering software at Meta as an Intern.")
                                         .logoLink("https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Meta_Platforms_Inc._logo_%28cropped%29.svg/75px-Meta_Platforms_Inc._logo_%28cropped%29.svg.png")
-                                        .companyLink(null)
+                                        .organizationLink(null)
                                         .build();
 
     private Skill skill = Skill.builder()
@@ -62,29 +62,32 @@ public class ExperienceControllerTest {
     
     @Test
     public void testGetExperiences() throws Exception {
-        List<Experience> experiences = new ArrayList<>(Arrays.asList(experience));
+        HashMap<String, List<Experience>> experiences = new HashMap<>();
+        experiences.put(ExperienceType.WORK_EXPERIENCE.name(), List.of(experience));
+        experiences.put(ExperienceType.EDUCATION.name(), List.of());
         given(experienceService.getExperiences()).willReturn(experiences);
         mockMvc.perform(MockMvcRequestBuilders.get("/experiences/get")
             .header("X-Forwarded-For", "localhost")
             .header("CF-Connecting-IP", "localhost"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.experiences", hasSize(1)))
-            .andExpect(jsonPath("$.experiences[0].id", is(experience.getId())))
-            .andExpect(jsonPath("$.experiences[0].position", is(experience.getPosition())))
-            .andExpect(jsonPath("$.experiences[0].company", is(experience.getCompany())))
-            .andExpect(jsonPath("$.experiences[0].location", is(experience.getLocation())))
-            .andExpect(jsonPath("$.experiences[0].startDate", is(experience.getStartDate())))
-            .andExpect(jsonPath("$.experiences[0].endDate", is(experience.getEndDate())))
-            .andExpect(jsonPath("$.experiences[0].present", is(experience.getPresent())))
-            .andExpect(jsonPath("$.experiences[0].body", is(experience.getBody())))
-            .andExpect(jsonPath("$.experiences[0].skills", hasSize(1)))
-            .andExpect(jsonPath("$.experiences[0].skills[0].id", is(skill.getId())))
-            .andExpect(jsonPath("$.experiences[0].skills[0].name", is(skill.getName())))
-            .andExpect(jsonPath("$.experiences[0].skills[0].type", is(skill.getType().getJsonValue())))
-            .andExpect(jsonPath("$.experiences[0].skills[0].link", is(skill.getLink())))
-            .andExpect(jsonPath("$.experiences[0].skills[0].simpleIconsIconSlug", is(skill.getSimpleIconsIconSlug())))
-            .andExpect(jsonPath("$.experiences[0].skills[0].hexFill", is(skill.getHexFill())))
-            .andExpect(jsonPath("$.experiences[0].logoLink", is(experience.getLogoLink())))
-            .andExpect(jsonPath("$.experiences[0].companyLink", is(experience.getCompanyLink())));
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE", hasSize(1)))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].id", is(experience.getId())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].position", is(experience.getPosition())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].organization", is(experience.getOrganization())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].location", is(experience.getLocation())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].startDate", is(experience.getStartDate())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].endDate", is(experience.getEndDate())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].present", is(experience.getPresent())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].body", is(experience.getBody())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills", hasSize(1)))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills[0].id", is(skill.getId())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills[0].name", is(skill.getName())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills[0].type", is(skill.getType().getJsonValue())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills[0].link", is(skill.getLink())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills[0].simpleIconsIconSlug", is(skill.getSimpleIconsIconSlug())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills[0].hexFill", is(skill.getHexFill())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].logoLink", is(experience.getLogoLink())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].organizationLink", is(experience.getOrganizationLink())))
+            .andExpect(jsonPath("$.experiences.EDUCATION", hasSize(0)));
     }
 }

--- a/backend/src/test/java/com/jasonpyau/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/jasonpyau/controller/ProjectControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.jasonpyau.entity.Project;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.repository.ProjectRepository;
 import com.jasonpyau.service.ProjectService;
 
@@ -47,7 +48,7 @@ public class ProjectControllerTest {
     private Skill skill = Skill.builder()
                             .id(1)
                             .name("Java")
-                            .type(Skill.Type.LANGUAGE)
+                            .type(SkillType.LANGUAGE)
                             .link("https://en.wikipedia.org/wiki/Java_(programming_language)")
                             .simpleIconsIconSlug("spring")
                             .hexFill("#ffffff")

--- a/backend/src/test/java/com/jasonpyau/controller/SkillControllerTest.java
+++ b/backend/src/test/java/com/jasonpyau/controller/SkillControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.service.SkillService;
 
 @WebMvcTest(SkillController.class)
@@ -30,7 +31,7 @@ public class SkillControllerTest {
     private Skill skill1 = Skill.builder()
                             .id(1)
                             .name("Java")
-                            .type(Skill.Type.LANGUAGE)
+                            .type(SkillType.LANGUAGE)
                             .link("https://en.wikipedia.org/wiki/Java_(programming_language)")
                             .simpleIconsIconSlug("java")
                             .hexFill("#ffffff")
@@ -39,7 +40,7 @@ public class SkillControllerTest {
     private Skill skill2 = Skill.builder()
                             .id(2)
                             .name("Git")
-                            .type(Skill.Type.SOFTWARE)
+                            .type(SkillType.SOFTWARE)
                             .link("https://en.wikipedia.org/wiki/Git")
                             .simpleIconsIconSlug("git")
                             .hexFill("#ffffff")

--- a/backend/src/test/java/com/jasonpyau/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/jasonpyau/repository/UserRepositoryTest.java
@@ -31,6 +31,6 @@ public class UserRepositoryTest {
         String hashedAddress = Hash.SHA256("localhost");
         user.setAddress(hashedAddress);
         userRepository.save(user);
-        assertEquals(userRepository.findUserByAddress(hashedAddress).isPresent(), true);
+        assertEquals(userRepository.findByAddress(hashedAddress).isPresent(), true);
     }
 }

--- a/backend/src/test/java/com/jasonpyau/service/ContactServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/ContactServiceTest.java
@@ -1,5 +1,6 @@
 package com.jasonpyau.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.jasonpyau.entity.Message;
 import com.jasonpyau.exception.ResourceNotFoundException;
 import com.jasonpyau.repository.ContactRepository;
-import com.jasonpyau.util.DateFormat;
 
 @ExtendWith(MockitoExtension.class)
 public class ContactServiceTest {
@@ -28,11 +28,23 @@ public class ContactServiceTest {
     @InjectMocks
     private ContactService contactService;
 
-    private Message message1 = new Message(1L, "Message1", "test1@gmail.com", "This is a test body of Message1", DateFormat.yyyyMMddHHmmss());
+    private Message message;
+
+    @BeforeEach
+    public void setUp() {
+        this.message = Message.builder()
+        .id(1L)
+        .name("Jason Yau")
+        .contactInfo("test@jasonpyau.com")
+        .body("This is a test body of the message!")
+        .date(null)
+        .sender(null)
+        .build();
+    }
 
     @Test
     void testDeleteMessage() {
-        given(contactRepository.findById(1L)).willReturn(Optional.of(message1));
+        given(contactRepository.findById(1L)).willReturn(Optional.of(message));
         assertDoesNotThrow(() -> {
             contactService.deleteMessage(1L);
         });

--- a/backend/src/test/java/com/jasonpyau/service/ExperienceServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/ExperienceServiceTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Experience.ExperienceType;
 import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.exception.ResourceNotFoundException;
 import com.jasonpyau.repository.ExperienceRepository;
@@ -36,15 +37,16 @@ public class ExperienceServiceTest {
 
     private Experience experience = Experience.builder()
                                         .id(1)
+                                        .type(ExperienceType.WORK_EXPERIENCE)
                                         .position("Software Engineer Intern")
-                                        .company("Meta")
+                                        .organization("Meta")
                                         .location("Menlo Park, CA")
                                         .startDate("05/2024")
                                         .endDate("08/2024")
                                         .present(false)
                                         .body("Software Engineer Intern working on engineering software at Meta as an Intern.")
                                         .logoLink("https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Meta_Platforms_Inc._logo_%28cropped%29.svg/75px-Meta_Platforms_Inc._logo_%28cropped%29.svg.png")
-                                        .companyLink(null)
+                                        .organizationLink(null)
                                         .build();
 
     private Skill skill = Skill.builder()

--- a/backend/src/test/java/com/jasonpyau/service/ExperienceServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/ExperienceServiceTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.exception.ResourceNotFoundException;
 import com.jasonpyau.repository.ExperienceRepository;
 
@@ -49,7 +50,7 @@ public class ExperienceServiceTest {
     private Skill skill = Skill.builder()
                             .id(1)
                             .name("Java")
-                            .type(Skill.Type.LANGUAGE)
+                            .type(SkillType.LANGUAGE)
                             .link("https://en.wikipedia.org/wiki/Java_(programming_language)")
                             .simpleIconsIconSlug("java")
                             .hexFill("#ffffff")

--- a/backend/src/test/java/com/jasonpyau/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/ProjectServiceTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.jasonpyau.entity.Project;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.exception.ResourceNotFoundException;
 import com.jasonpyau.repository.ProjectRepository;
 
@@ -46,7 +47,7 @@ public class ProjectServiceTest {
     private Skill skill = Skill.builder()
                             .id(1)
                             .name("Java")
-                            .type(Skill.Type.LANGUAGE)
+                            .type(SkillType.LANGUAGE)
                             .link("https://en.wikipedia.org/wiki/Java_(programming_language)")
                             .simpleIconsIconSlug("java")
                             .hexFill("#ffffff")

--- a/backend/src/test/java/com/jasonpyau/service/SkillServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/SkillServiceTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.exception.ResourceAlreadyExistsException;
 import com.jasonpyau.repository.SkillRepository;
 
@@ -33,7 +34,7 @@ public class SkillServiceTest {
     private Skill java = Skill.builder()
                             .id(1)
                             .name("Java")
-                            .type(Skill.Type.LANGUAGE)
+                            .type(SkillType.LANGUAGE)
                             .link("https://en.wikipedia.org/wiki/Java_(programming_language)")
                             .simpleIconsIconSlug("java")
                             .hexFill("#ffffff")
@@ -42,7 +43,7 @@ public class SkillServiceTest {
     private Skill springBoot = Skill.builder()
                             .id(1)
                             .name("Spring Boot")
-                            .type(Skill.Type.FRAMEWORK_OR_LIBRARY)
+                            .type(SkillType.FRAMEWORK_OR_LIBRARY)
                             .link("https://en.wikipedia.org/wiki/Spring_Boot")
                             .simpleIconsIconSlug("springboot")
                             .hexFill("#ffffff")
@@ -58,21 +59,21 @@ public class SkillServiceTest {
     }
 
     @Test void getSkills() {
-        given(skillRepository.findAllSkillsByTypeName(Skill.Type.LANGUAGE.name())).willReturn(List.of(java));
-        given(skillRepository.findAllSkillsByTypeName(Skill.Type.FRAMEWORK_OR_LIBRARY.name())).willReturn(List.of(springBoot));
+        given(skillRepository.findAllSkillsByTypeName(SkillType.LANGUAGE.name())).willReturn(List.of(java));
+        given(skillRepository.findAllSkillsByTypeName(SkillType.FRAMEWORK_OR_LIBRARY.name())).willReturn(List.of(springBoot));
         assertDoesNotThrow(() -> {
             HashMap<String, List<Skill>> skills = skillService.getSkills();
             assertNotEquals(skills, null);
-            assertNotEquals(skills.get(Skill.Type.LANGUAGE.getJsonValue()), null);
-            assertEquals(skills.get(Skill.Type.LANGUAGE.getJsonValue()).size(), 1);
-            assertEquals(skills.get(Skill.Type.LANGUAGE.getJsonValue()).get(0), java);
-            assertNotEquals(skills.get(Skill.Type.FRAMEWORK_OR_LIBRARY.getJsonValue()), null);
-            assertEquals(skills.get(Skill.Type.FRAMEWORK_OR_LIBRARY.getJsonValue()).size(), 1);
-            assertEquals(skills.get(Skill.Type.FRAMEWORK_OR_LIBRARY.getJsonValue()).get(0), springBoot);
-            assertNotEquals(skills.get(Skill.Type.DATABASE.getJsonValue()), null);
-            assertEquals(skills.get(Skill.Type.DATABASE.getJsonValue()).size(), 0);
-            assertNotEquals(skills.get(Skill.Type.SOFTWARE.getJsonValue()), null);
-            assertEquals(skills.get(Skill.Type.SOFTWARE.getJsonValue()).size(), 0);
+            assertNotEquals(skills.get(SkillType.LANGUAGE.getJsonValue()), null);
+            assertEquals(skills.get(SkillType.LANGUAGE.getJsonValue()).size(), 1);
+            assertEquals(skills.get(SkillType.LANGUAGE.getJsonValue()).get(0), java);
+            assertNotEquals(skills.get(SkillType.FRAMEWORK_OR_LIBRARY.getJsonValue()), null);
+            assertEquals(skills.get(SkillType.FRAMEWORK_OR_LIBRARY.getJsonValue()).size(), 1);
+            assertEquals(skills.get(SkillType.FRAMEWORK_OR_LIBRARY.getJsonValue()).get(0), springBoot);
+            assertNotEquals(skills.get(SkillType.DATABASE.getJsonValue()), null);
+            assertEquals(skills.get(SkillType.DATABASE.getJsonValue()).size(), 0);
+            assertNotEquals(skills.get(SkillType.SOFTWARE.getJsonValue()), null);
+            assertEquals(skills.get(SkillType.SOFTWARE.getJsonValue()).size(), 0);
         });
     }
 }

--- a/backend/src/test/java/com/jasonpyau/service/SkillServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/SkillServiceTest.java
@@ -51,7 +51,7 @@ public class SkillServiceTest {
 
     @Test
     public void newSkill_SkillAlreadyExistsError() {
-        given(skillRepository.findSkillByName("Java")).willReturn(Optional.of(java));
+        given(skillRepository.findByName("Java")).willReturn(Optional.of(java));
         ResourceAlreadyExistsException e = assertThrows(ResourceAlreadyExistsException.class, () -> {
             skillService.newSkill(java);
         });
@@ -59,8 +59,8 @@ public class SkillServiceTest {
     }
 
     @Test void getSkills() {
-        given(skillRepository.findAllSkillsByTypeName(SkillType.LANGUAGE.name())).willReturn(List.of(java));
-        given(skillRepository.findAllSkillsByTypeName(SkillType.FRAMEWORK_OR_LIBRARY.name())).willReturn(List.of(springBoot));
+        given(skillRepository.findAllByTypeNameOrderedByName(SkillType.LANGUAGE.name())).willReturn(List.of(java));
+        given(skillRepository.findAllByTypeNameOrderedByName(SkillType.FRAMEWORK_OR_LIBRARY.name())).willReturn(List.of(springBoot));
         assertDoesNotThrow(() -> {
             HashMap<String, List<Skill>> skills = skillService.getSkills();
             assertNotEquals(skills, null);


### PR DESCRIPTION
- Add enum `Experience.ExperienceType`: `WORK_EXPERIENCE` and `EDUCATION`
- Split Experience section in frontend to Work Experience (Experience) and Education
- Link the `Message` entity to the `User` entity for better message tracking 
- Allow hrefs in the `Link` entity to start with `/`
- Rename `company` and `companyLink` fields in the `Experience` entity to `organization` and `organizationLink`, respectively. The following SQL commands need to be ran on MariaDB to migrate these changes successfully:
```sql
ALTER TABLE `experiences` CHANGE `company` `organization` VARCHAR(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;
ALTER TABLE `experiences` CHANGE `company_link` `organization_link` VARCHAR(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL;
```
- Rename enum `Skill.Type` to `Skill.SkillType`
- Add logic in `experiences.js` to view the number of months and years from `startDate` to `endDate` (inspired by LinkedIn)
- Rename query functions in Repository classes to be more consistent and clear
- Use StringUtils.hasText instead of checking null and blank string throughout the repository
- Miscellaneous bug fixes