### PR TITLE
Add lazy loading to img elements in the home page, small frontend changes, bump versions

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.6</version>
+		<version>3.3.8</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.jasonpyau</groupId>

--- a/backend/src/main/resources/static/javascript/experiences.js
+++ b/backend/src/main/resources/static/javascript/experiences.js
@@ -36,7 +36,7 @@ function loadExperiences(experiences, type) {
         if (type === "WORK_EXPERIENCE") {
             experienceElement.innerHTML = `
                 <div class="Rounded Experience my-1 py-2 border border-white" id="Experience${experience.id}">
-                    <div class="fs-3 fw-bold mx-4 my-2 text-decoration-underline" id="Position">
+                    <div class="fs-3 fw-bold mx-4 my-2" id="Position">
                         ${experience.position}
                     </div>
                     <div class="d-flex mx-4">
@@ -63,7 +63,7 @@ function loadExperiences(experiences, type) {
                             </div>
                         </div>
                         ${experience.organizationLink ? `<a href="${experience.organizationLink}" target="_blank" class="opaque_when_hovered">` : ""}
-                            <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}" title="${experience.organization}" alt="${experience.organization} Logo"/>
+                            <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}" title="${experience.organization}" alt="${experience.organization} Logo" loading="lazy"/>
                         ${experience.organizationLink ? `</a>` : ""}
                         </div>
                 </div>
@@ -95,7 +95,7 @@ function loadExperiences(experiences, type) {
                             </div>
                         </div>
                         ${experience.organizationLink ? `<a href="${experience.organizationLink}" target="_blank" class="opaque_when_hovered">` : ""}
-                            <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}" title="${experience.organization}" alt="${experience.organization} Logo"/>
+                            <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}" title="${experience.organization}" alt="${experience.organization} Logo" loading="lazy"/>
                         ${experience.organizationLink ? `</a>` : ""}
                     </div>
                 </div>

--- a/backend/src/main/resources/static/javascript/skills.js
+++ b/backend/src/main/resources/static/javascript/skills.js
@@ -41,7 +41,7 @@ function loadSkill(skill, container) {
     element.className = "m-1 btn btn-dark btn-sm";
     element.innerHTML = `
         <a class="text-decoration-none text-white" title="${skill.name}" ${(skill.link) ? `href="${skill.link}" target="_blank"` : `href="javascript:void(0);"`}>
-            ${skill.simpleIconsIconSlug ? `<img src="/skills/svg/${encodeURIComponent(skill.name)}" class="mx-1" height="16px" width="16px"/>` : ""}
+            ${skill.simpleIconsIconSlug ? `<img src="/skills/svg/${encodeURIComponent(skill.name)}" class="mx-1" height="16px" width="16px" alt="${skill.name} Icon" loading="lazy"/>` : ""}
             <span>
                 ${skill.name}
             </span>

--- a/backend/src/main/resources/templates/index.html
+++ b/backend/src/main/resources/templates/index.html
@@ -95,7 +95,7 @@
                     </div>
                     <div class="mb-3">
                         You may opt to contact me via
-                        <a href="links" title="Socials">Email / Linkedin.</a>
+                        <a class="text-white opaque_when_hovered" href="/links" title="Socials">Email / Linkedin.</a>
                     </div>
                 </div>
             </div>

--- a/backend/src/main/resources/templates/links.html
+++ b/backend/src/main/resources/templates/links.html
@@ -18,7 +18,7 @@
     <div class="bg-gradient bg-dark" id="BodyContainer">
         <div class="d-flex flex-column align-items-center my-2" th:each="link: ${links}">
             <a th:href="${link.href}" target="_blank" class="p-2 LinkButton opaque_when_hovered" th:title="${link.name}">
-                <img th:if="${link.simpleIconsIconSlug != null && !link.simpleIconsIconSlug.isBlank()}" width="16px" height="16px" th:src="'/links/svg/'+${link.id}" class="mx-2"/>
+                <img th:if="${link.simpleIconsIconSlug != null && !link.simpleIconsIconSlug.isBlank()}" width="16px" height="16px" th:src="'/links/svg/'+${link.id}" class="mx-2" th:alt="${link.name}+' Icon'"/>
                 <span th:text="${link.name}"></span>
             </a>
         </div>

--- a/backend/src/main/resources/templates/template.html
+++ b/backend/src/main/resources/templates/template.html
@@ -84,14 +84,14 @@
             </div>
         </a>
         <div class="fs-6 my-3">
-            <a href="https://app.swaggerhub.com/apis-docs/jasonpyau-com/jasonpyau.com/1.0.0" class="NoDecoration" target="_blank" title="SwaggerHub">
+            <a href="https://app.swaggerhub.com/apis-docs/jasonpyau-com/jasonpyau.com/1.0.0" class="opaque_when_hovered NoDecoration" target="_blank" title="SwaggerHub">
                 <u>
                     API Documentation
                 </u>
             </a>
         </div>
         <div class="fs-6 my-3">
-            <a href="https://directory.jasonpyau.com" class="NoDecoration" title="Web Directory">
+            <a href="https://directory.jasonpyau.com" class="opaque_when_hovered NoDecoration" title="Web Directory">
                 <u>
                     [Directory]
                 </u>


### PR DESCRIPTION
- Add lazy loading to `img` elements in the home page
- Add `alt` attributes to a few `img` elements
- Add more consistent styling to anchor (`a`) elements
- Bump version: Spring Boot v3.3.8: CVE-2024-12798, CVE-2024-12801