### PR TITLE
Refactor an experience to be able to have multiple positions, patch security vulnerabilities, fix VS Code warnings

### DIFF
--- a/admin/AdminPanel.java
+++ b/admin/AdminPanel.java
@@ -87,6 +87,45 @@ public class AdminPanel {
         apiCall("/experiences/get", "{ }", "GET", false);
     }
 
+    private static void newExperiencePosition() {
+        System.out.println("Input id of the experience you'd like to add a position to:");
+        String id = scan.nextLine();
+        System.out.println("Input experience position name:");
+        String positionName = scan.nextLine();
+        System.out.println("Input startDate ('MM/YYYY') of experience position");
+        String startDate = scan.nextLine();
+        System.out.println("Are you currently working in this experience position? [true/false]");
+        String present = scan.nextLine();
+        String endDate = null;
+        if (present.equals("true")) {
+            // Currently, endDate is a required field even if present = true. 
+            // The server has logic to always update the endDate to the current month. 
+            endDate = "12/2099";
+        } else {
+            System.out.println("Input endDate ('MM/YYYY') of experience position");
+            endDate = scan.nextLine();
+        }
+        String body = "{\"positionName\": \""+positionName+"\"," +
+                        "\"startDate\": \""+startDate+"\"," +
+                        "\"present\": \""+present+"\"," +
+                        "\"endDate\": \""+endDate+"\"}";
+        boolean success = apiCall(String.format("/experiences/%s/positions/new", id), body, "POST", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
+    }
+
+    private static void deleteExperiencePosition() {
+        System.out.println("Input id of the experience you'd like to remove a position from:");
+        String id = scan.nextLine();
+        System.out.println("Input the name of the position:");
+        String positionName = URLEncoder.encode(scan.nextLine(), StandardCharsets.UTF_8);
+        boolean success = apiCall(String.format("/experiences/%s/positions/delete?positionName=%s", id, positionName), "{ }", "DELETE", true);
+        if (success) {
+            updateLastUpdated(false);
+        }
+    }
+
     private static void newExperienceSkill() {
         System.out.println("Input id of the experience you'd like to add a skill to:");
         String id = scan.nextLine();
@@ -511,7 +550,9 @@ public class AdminPanel {
             System.out.println("4.) View Experiences");
             System.out.println("5.) Add Skill to Experience");
             System.out.println("6.) Delete Skill from Experience");
-            System.out.println("7.) Back");
+            System.out.println("7.) Add Position to Experience");
+            System.out.println("8.) Delete Position from Experience");
+            System.out.println("9.) Back");
             String input = scan.nextLine();
             switch (input) {
                 case "1":
@@ -533,6 +574,12 @@ public class AdminPanel {
                     deleteExperienceSkill();
                     break;
                 case "7":
+                    newExperiencePosition();
+                    break;
+                case "8":
+                    deleteExperiencePosition();
+                    break;
+                case "9":
                     return;
                 default:
                     System.out.println("Invald input.");
@@ -636,30 +683,12 @@ public class AdminPanel {
         System.out.println("These are the valid types. Input the type of experience:");
         input = scan.nextLine();
         sb.append("{\"type\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
-        System.out.println("Input experience position:");
-        input = scan.nextLine();
-        sb.append("\"position\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
         System.out.println("Input experience organization/company:");
         input = scan.nextLine();
         sb.append("\"organization\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
         System.out.println("Input experience location:");
         input = scan.nextLine();
         sb.append("\"location\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
-        System.out.println("Input startDate ('MM/YYYY') of experience");
-        input = scan.nextLine();
-        sb.append("\"startDate\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
-        System.out.println("Is the experience currently being worked on? [true/false]");
-        input = scan.nextLine();
-        sb.append("\"present\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
-        if (input.equals("true")) {
-            // Currently, endDate is a required field even if present = true. 
-            // The server has logic to always update the endDate to the current month. 
-            input = "12/2099";
-        } else {
-            System.out.println("Input endDate ('MM/YYYY') of experience");
-            input = scan.nextLine();
-        }
-        sb.append("\"endDate\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");
         System.out.println("Input experience body (description):");
         input = scan.nextLine();
         sb.append("\"body\": " + ((!input.isBlank()) ? "\""+input+"\"" : "null") + ", ");

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.2</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.jasonpyau</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jackson</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>

--- a/backend/src/main/java/com/jasonpyau/annotation/RateLimitAspect.java
+++ b/backend/src/main/java/com/jasonpyau/annotation/RateLimitAspect.java
@@ -6,7 +6,6 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.jasonpyau.exception.RateLimitException;
@@ -14,13 +13,14 @@ import com.jasonpyau.service.RateLimitService;
 
 import io.github.bucket4j.ConsumptionProbe;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class RateLimitAspect {
 
-    @Autowired
-    private RateLimitService rateLimitService;
+    private final RateLimitService rateLimitService;
     
     @Around("@annotation(RateLimit)")
     public Object rateLimit(ProceedingJoinPoint joinPoint) throws Throwable {

--- a/backend/src/main/java/com/jasonpyau/controller/AboutMeController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/AboutMeController.java
@@ -2,7 +2,6 @@ package com.jasonpyau.controller;
 
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -19,13 +18,14 @@ import com.jasonpyau.util.Response;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Controller
+@RequiredArgsConstructor
 @RequestMapping("/about_me")
 public class AboutMeController {
     
-    @Autowired
-    private AboutMeService aboutMeService;
+    private final AboutMeService aboutMeService;
 
     @PutMapping(path = "/update", consumes = "application/json", produces = "application/json")
     @AuthorizeAdmin

--- a/backend/src/main/java/com/jasonpyau/controller/BlogController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/BlogController.java
@@ -2,7 +2,6 @@ package com.jasonpyau.controller;
 
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -26,14 +25,15 @@ import com.jasonpyau.util.Response;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Controller
 @Validated
+@RequiredArgsConstructor
 @RequestMapping(path="/blogs")
 public class BlogController {
     
-    @Autowired
-    private BlogService blogService;
+    private final BlogService blogService;
 
     @PostMapping(path = "/new", consumes = "application/json", produces = "application/json")
     @RateLimit(RateLimit.ADMIN_TOKEN)

--- a/backend/src/main/java/com/jasonpyau/controller/ContactController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/ContactController.java
@@ -2,7 +2,6 @@ package com.jasonpyau.controller;
 
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -24,14 +23,15 @@ import com.jasonpyau.util.Response;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Controller
 @Validated
+@RequiredArgsConstructor
 @RequestMapping(path="/contact")
 public class ContactController {
     
-    @Autowired
-    private ContactService contactService;
+    private final ContactService contactService;
     
     @PostMapping(path = "/send", consumes = "application/json", produces = "application/json")
     @RateLimit(RateLimit.EXPENSIVE_TOKEN)

--- a/backend/src/main/java/com/jasonpyau/controller/ExperienceController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/ExperienceController.java
@@ -19,6 +19,7 @@ import com.jasonpyau.annotation.AuthorizeAdmin;
 import com.jasonpyau.annotation.RateLimit;
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
+import com.jasonpyau.entity.Experience.Position;
 import com.jasonpyau.service.ExperienceService;
 import com.jasonpyau.util.Response;
 
@@ -81,6 +82,26 @@ public class ExperienceController {
                                                                     @PathVariable("id") Integer id, 
                                                                     @RequestParam(required = true) @Size(min = 1, max = 25, message = Skill.SKILL_NAME_ERROR) String skillName) {
         experienceService.deleteExperienceSkill(skillName, id);
+        return Response.success();
+    }
+
+    @PostMapping(path = "{id}/positions/new", produces = "application/json")
+    @AuthorizeAdmin
+    @RateLimit(RateLimit.ADMIN_TOKEN)
+    @CrossOrigin
+    public ResponseEntity<HashMap<String, Object>> newExperiencePosition(HttpServletRequest request, @Valid @RequestBody Position position, @PathVariable("id") Integer id) {
+        experienceService.newExperiencePosition(position, id);
+        return Response.success();
+    }
+
+    @DeleteMapping(path = "{id}/positions/delete", produces = "application/json")
+    @AuthorizeAdmin
+    @RateLimit(RateLimit.ADMIN_TOKEN)
+    @CrossOrigin
+    public ResponseEntity<HashMap<String, Object>> deleteExperiencePosition(HttpServletRequest request, 
+                                                                    @PathVariable("id") Integer id, 
+                                                                    @RequestParam(required = true) @Size(min = 1, max = 50, message = Position.EXPERIENCE_POSITION_NAME_ERROR) String positionName) {
+        experienceService.deleteExperiencePosition(positionName, id);
         return Response.success();
     }
 

--- a/backend/src/main/java/com/jasonpyau/controller/ExperienceController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/ExperienceController.java
@@ -2,7 +2,6 @@ package com.jasonpyau.controller;
 
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
@@ -26,14 +25,15 @@ import com.jasonpyau.util.Response;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
 
 @Controller
 @Validated
+@RequiredArgsConstructor
 @RequestMapping(path = "/experiences")
 public class ExperienceController {
     
-    @Autowired
-    private ExperienceService experienceService;
+    private final ExperienceService experienceService;
 
     @PostMapping(path = "/new", consumes = "application/json", produces = "application/json")
     @AuthorizeAdmin

--- a/backend/src/main/java/com/jasonpyau/controller/FrontendController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/FrontendController.java
@@ -3,7 +3,6 @@ package com.jasonpyau.controller;
 import java.io.IOException;
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Controller;
@@ -25,18 +24,16 @@ import com.jasonpyau.util.NumberFormat;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Controller
+@RequiredArgsConstructor
 public class FrontendController {
 
-    @Autowired
-    private MetadataService metadataService;
-    @Autowired
-    private BlogService blogService;
-    @Autowired
-    private AboutMeService aboutMeService;
-    @Autowired
-    private LinkService linkService;
+    private final MetadataService metadataService;
+    private final BlogService blogService;
+    private final AboutMeService aboutMeService;
+    private final LinkService linkService;
     
     @GetMapping("/")
     @RateLimit(RateLimit.DEFAULT_TOKEN)

--- a/backend/src/main/java/com/jasonpyau/controller/LinkController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/LinkController.java
@@ -3,7 +3,6 @@ package com.jasonpyau.controller;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -25,14 +24,15 @@ import com.jasonpyau.util.Response;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Controller
 @Validated
+@RequiredArgsConstructor
 @RequestMapping(path="/links")
 public class LinkController {
 
-    @Autowired
-    private LinkService linkService;
+    private final LinkService linkService;
 
     @PostMapping(path = "/new", consumes = "application/json", produces = "application/json")
     @AuthorizeAdmin

--- a/backend/src/main/java/com/jasonpyau/controller/MetadataController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/MetadataController.java
@@ -2,7 +2,6 @@ package com.jasonpyau.controller;
 
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -18,13 +17,14 @@ import com.jasonpyau.service.MetadataService;
 import com.jasonpyau.util.Response;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
 @Controller
+@RequiredArgsConstructor
 @RequestMapping(path="/metadata")
 public class MetadataController {
 
-    @Autowired
-    private MetadataService metadataService;
+    private final MetadataService metadataService;
 
     @GetMapping(path = "/get", produces = "application/json")
     @RateLimit(RateLimit.DEFAULT_TOKEN)

--- a/backend/src/main/java/com/jasonpyau/controller/ProjectController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/ProjectController.java
@@ -2,7 +2,6 @@ package com.jasonpyau.controller;
 
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
@@ -26,14 +25,15 @@ import com.jasonpyau.util.Response;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
 
 @Controller
 @Validated
+@RequiredArgsConstructor
 @RequestMapping(path = "/projects")
 public class ProjectController {
     
-    @Autowired
-    private ProjectService projectService;
+    private final ProjectService projectService;
 
     @PostMapping(path = "/new", consumes = "application/json", produces = "application/json")
     @AuthorizeAdmin

--- a/backend/src/main/java/com/jasonpyau/controller/SkillController.java
+++ b/backend/src/main/java/com/jasonpyau/controller/SkillController.java
@@ -3,7 +3,6 @@ package com.jasonpyau.controller;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -24,13 +23,14 @@ import com.jasonpyau.util.Response;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Controller
+@RequiredArgsConstructor
 @RequestMapping(path = "/skills")
 public class SkillController {
 
-    @Autowired
-    private SkillService skillService;
+    private final SkillService skillService;
 
     @PostMapping(path = "/new", consumes = "application/json", produces = "application/json")
     @AuthorizeAdmin

--- a/backend/src/main/java/com/jasonpyau/entity/Experience.java
+++ b/backend/src/main/java/com/jasonpyau/entity/Experience.java
@@ -1,10 +1,17 @@
 package com.jasonpyau.entity;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jasonpyau.util.DateFormat;
 
 import jakarta.persistence.Column;
@@ -19,6 +26,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -26,6 +34,7 @@ import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -39,19 +48,70 @@ import lombok.Setter;
 @Table(name="experiences", indexes = @Index(name = "date_order_ind", columnList = "date_order"))
 public class Experience {
 
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    public static class Position implements Comparable<Position> {
+        public static final String EXPERIENCE_POSITION_NOT_FOUND_ERROR = "Position with the same 'positionName' does not exist.";
+        public static final String EXPERIENCE_POSITION_ALREADY_EXISTS_ERROR = "Position with the same 'positionName' already exists.";
+        public static final String EXPERIENCE_POSITION_NAME_ERROR = "'positionName' should be between 1-50 characters.";
+        public static final String EXPERIENCE_POSITION_START_DATE_ERROR = "'startDate' should be in format 'MM/YYYY'.";
+        public static final String EXPERIENCE_POSITION_END_DATE_ERROR = "'endDate' should be in format 'MM/YYYY'.";
+        public static final String EXPERIENCE_POSITION_PRESENT_ERROR = "'present' should be true or false.";
+        
+        @EqualsAndHashCode.Include
+        @Size(min = 1, max = 50, message = EXPERIENCE_POSITION_NAME_ERROR)
+        @NotBlank(message = EXPERIENCE_POSITION_NAME_ERROR)
+        private String positionName;
+        
+        @Pattern(regexp = "^(0[1-9]|1[0-2])/[1-2]{1}[0-9]{3}$", message = EXPERIENCE_POSITION_START_DATE_ERROR)
+        @NotBlank(message = EXPERIENCE_POSITION_START_DATE_ERROR)
+        private String startDate;
+        
+        @Pattern(regexp = "^(0[1-9]|1[0-2])/[1-2]{1}[0-9]{3}$", message = EXPERIENCE_POSITION_END_DATE_ERROR)
+        @NotBlank(message = EXPERIENCE_POSITION_END_DATE_ERROR)
+        private String endDate;
+        
+        @NotNull(message = EXPERIENCE_POSITION_PRESENT_ERROR)
+        private Boolean present;
+
+        public static String getSortKey(String startDate, String endDate, Boolean present) {
+            if (startDate == null || endDate == null || present == null) {
+                return "0".repeat(13);
+            }
+            String[] startSplit = startDate.split("/", 2);
+            String[] endSplit = endDate.split("/", 2);
+            // EndYYYY+EndMM+present+StartYYYY+StartMM
+            return endSplit[1]
+                + endSplit[0]
+                + (present ? "1" : "0")
+                + startSplit[1]
+                + startSplit[0];
+        }
+        
+        @JsonIgnore
+        public String getSortKey() {
+            return getSortKey(startDate, endDate, present);
+        }
+
+        @Override
+        public int compareTo(Position other) {
+            return other.getSortKey().compareTo(this.getSortKey());
+        }
+    }
+
     public enum ExperienceType {
         WORK_EXPERIENCE,
         EDUCATION;
     }
 
     public static final String EXPERIENCE_ID_ERROR = "Invalid 'id', experience not found.";
-    public static final String EXPERIENCE_POSITION_ERROR = "'position' should be between 1-50 characters.";
     public static final String EXPERIENCE_ORGANIZATION_ERROR = "'organization' should be between 1-50 characters.";
     public static final String EXPERIENCE_LOCATION_ERROR = "'location' should be between 1-30 characters.";
-    public static final String EXPERIENCE_START_DATE_ERROR = "'startDate' should be in format 'MM/YYYY'.";
-    public static final String EXPERIENCE_END_DATE_ERROR = "'endDate' should be in format 'MM/YYYY'.";
-    public static final String EXPERIENCE_PRESENT_ERROR = "'present' should be true or false.";
-    public static final String EXPERIENCE_BODY_ERROR = "'body' should be between 1-1000 characters.";
+    public static final String EXPERIENCE_BODY_ERROR = "'body' should be between 1-2000 characters.";
     public static final String EXPERIENCE_LOGO_LINK_ERROR = "'logoLink' should be between 2-500 characters and start with 'http://' or 'https://' or '/'.";
     public static final String EXPERIENCE_ORGANIZATION_LINK_ERROR = "'organizationLink' should be between 0-250 characters and if not empty, start with 'http://' or 'https://'.";
     public static final String EXPERIENCE_TYPE_ERROR = "'type' should be one of the following: "+validTypes()
@@ -71,11 +131,6 @@ public class Experience {
     @NotNull(message = EXPERIENCE_TYPE_NULL_ERROR)
     private ExperienceType type;
 
-    @Column(name = "position", nullable = false)
-    @Size(min = 1, max = 50, message = EXPERIENCE_POSITION_ERROR)
-    @NotBlank(message = EXPERIENCE_POSITION_ERROR)
-    private String position;
-
     @Column(name = "organization", nullable = false)
     @Size(min = 1, max = 50, message = EXPERIENCE_ORGANIZATION_ERROR)
     @NotBlank(message = EXPERIENCE_ORGANIZATION_ERROR)
@@ -86,19 +141,11 @@ public class Experience {
     @NotBlank(message = EXPERIENCE_LOCATION_ERROR)
     private String location;
 
-    @Column(name = "start_date", nullable = false)
-    @Pattern(regexp = "^(0[1-9]|1[0-2])/20[0-9]{2}$", message = EXPERIENCE_START_DATE_ERROR)
-    @NotBlank(message = EXPERIENCE_START_DATE_ERROR)
-    private String startDate;
-
-    @Column(name = "end_date", nullable = false)
-    @Pattern(regexp = "^(0[1-9]|1[0-2])/20[0-9]{2}$", message = EXPERIENCE_END_DATE_ERROR)
-    @NotBlank(message = EXPERIENCE_END_DATE_ERROR)
-    private String endDate;
-
-    @Column(name = "present", nullable = false)
-    @NotNull(message = EXPERIENCE_PRESENT_ERROR)
-    private Boolean present;
+    @Column(name = "positions", nullable = false)
+    @Valid
+    @JdbcTypeCode(SqlTypes.JSON)
+    @JsonIgnore
+    private final Set<Position> positions = new HashSet<>();
 
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
@@ -127,22 +174,26 @@ public class Experience {
     private String organizationLink;
 
     public void createOrder() {
-        String[] startSplit = this.startDate.split("/", 2);
-        String[] endSplit = this.endDate.split("/", 2);
-        // EndYYYY+EndMM+present+StartYYYY+StartMM
-        this.dateOrder = endSplit[1]
-                        + endSplit[0]
-                        + ((this.present) ? "1" : "0")
-                        + startSplit[1]
-                        + startSplit[0];
+        if (positions.isEmpty()) {
+            this.dateOrder = Position.getSortKey(null, null, null);
+        } else {
+            String firstStartDate = Collections.min(positions.stream().map(Position::getStartDate).toList());
+            String lastEndDate = Collections.max(positions.stream().map(Position::getEndDate).toList());
+            boolean hasPresent = positions.stream().anyMatch(Position::getPresent);
+            this.dateOrder = Position.getSortKey(firstStartDate, lastEndDate, hasPresent);
+        }
     }
 
-    // Returns true if there was a change to the experience's endDate.
+    // Returns true if there was a change to an endDate.
     public boolean syncEndDate() {
         boolean changed = false;
-        if (this.present) {
-            changed = !this.endDate.equals(DateFormat.MMyyyy());
-            this.endDate = DateFormat.MMyyyy();
+        for (Position position : positions) {
+            if (position.present) {
+                changed = !position.endDate.equals(DateFormat.MMyyyy());
+                position.endDate = DateFormat.MMyyyy();
+            }
+        }
+        if (changed) {
             createOrder();
         }
         return changed;
@@ -160,5 +211,14 @@ public class Experience {
 
     public static List<String> validTypes() {
         return Arrays.stream(ExperienceType.values()).map(ExperienceType::name).toList();
+    }
+
+    @JsonProperty("positions")
+    public List<Position> sortedPositions() {
+        return positions.stream().sorted().toList();
+    }
+
+    public Optional<Position> getPosition(String positionName) {
+        return positions.stream().filter(position -> position.getPositionName().equals(positionName)).findFirst();
     }
 }

--- a/backend/src/main/java/com/jasonpyau/repository/AboutMeRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/AboutMeRepository.java
@@ -1,11 +1,9 @@
 package com.jasonpyau.repository;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.AboutMe;
 
-@Repository
 public interface AboutMeRepository extends CrudRepository<AboutMe, Integer> {
     
 }

--- a/backend/src/main/java/com/jasonpyau/repository/BlogRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/BlogRepository.java
@@ -5,11 +5,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Blog;
 
-@Repository
 public interface BlogRepository extends JpaRepository<Blog, Long> {
 
     @Query(value = "SELECT * FROM blogs b "

--- a/backend/src/main/java/com/jasonpyau/repository/ContactRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/ContactRepository.java
@@ -4,11 +4,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Message;
 
-@Repository
 public interface ContactRepository extends JpaRepository<Message, Long> {
     @Query(value = "SELECT m from Message m LEFT JOIN FETCH m.sender ORDER BY date DESC", nativeQuery = false)
     public Page<Message> findAllJoinedWithSenderWithPaginationOrderedByDate(Pageable pageable);

--- a/backend/src/main/java/com/jasonpyau/repository/ExperienceRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/ExperienceRepository.java
@@ -5,11 +5,9 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Experience;
 
-@Repository
 public interface ExperienceRepository extends JpaRepository<Experience, Integer> {
     @Query(value = "SELECT * FROM experiences WHERE type = :type ORDER BY date_order DESC", nativeQuery = true)
     public List<Experience> findAllByTypeNameOrderedByDate(@Param("type") String type);

--- a/backend/src/main/java/com/jasonpyau/repository/LinkRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/LinkRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Link;
 
-@Repository
 public interface LinkRepository extends JpaRepository<Link, Integer> {
     @Query(value = "SELECT * from links ORDER BY last_updated_unix_time DESC", nativeQuery = true)
     public List<Link> findAllOrderedByLastUpdatedUnixTime();

--- a/backend/src/main/java/com/jasonpyau/repository/MetadataRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/MetadataRepository.java
@@ -1,11 +1,9 @@
 package com.jasonpyau.repository;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Metadata;
 
-@Repository
 public interface MetadataRepository extends CrudRepository<Metadata, Integer> {
     
 }

--- a/backend/src/main/java/com/jasonpyau/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/ProjectRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Project;
 
-@Repository
 public interface ProjectRepository extends JpaRepository<Project, Integer> {
     @Query(value = "SELECT * FROM projects ORDER BY date_order DESC", nativeQuery = true)
     public List<Project> findAllOrderedByDate();

--- a/backend/src/main/java/com/jasonpyau/repository/SkillRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/SkillRepository.java
@@ -6,11 +6,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.Skill;
 
-@Repository
 public interface SkillRepository extends JpaRepository<Skill, Integer> {
     @Query(value = "SELECT * FROM skills WHERE type = :type ORDER BY name ASC", nativeQuery = true)
     public List<Skill> findAllByTypeNameOrderedByName(@Param("type") String type);

--- a/backend/src/main/java/com/jasonpyau/repository/UserRepository.java
+++ b/backend/src/main/java/com/jasonpyau/repository/UserRepository.java
@@ -5,11 +5,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.jasonpyau.entity.User;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "SELECT * FROM users WHERE address = :address", nativeQuery = true)
     public Optional<User> findByAddress(@Param("address") String address);

--- a/backend/src/main/java/com/jasonpyau/service/AboutMeService.java
+++ b/backend/src/main/java/com/jasonpyau/service/AboutMeService.java
@@ -2,7 +2,6 @@ package com.jasonpyau.service;
 
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -11,11 +10,13 @@ import com.jasonpyau.entity.AboutMe;
 import com.jasonpyau.repository.AboutMeRepository;
 import com.jasonpyau.util.CacheUtil;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Service
 public class AboutMeService {
 
-    @Autowired
-    private AboutMeRepository aboutMeRepository;
+    private final AboutMeRepository aboutMeRepository;
     
     @CacheEvict(cacheNames = CacheUtil.ABOUT_ME_CACHE, allEntries = true)
     public void setAboutMe(AboutMe aboutMe) {

--- a/backend/src/main/java/com/jasonpyau/service/BlogService.java
+++ b/backend/src/main/java/com/jasonpyau/service/BlogService.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,14 +21,14 @@ import com.jasonpyau.repository.BlogRepository;
 import com.jasonpyau.util.DateFormat;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class BlogService {
 
-    @Autowired
-    private BlogRepository blogRepository;
-    @Autowired
-    private UserService userService;
+    private final BlogRepository blogRepository;
+    private final UserService userService;
 
     public void newBlog(NewBlogForm newBlogForm) {
         Blog blog = Blog.builder()

--- a/backend/src/main/java/com/jasonpyau/service/ContactService.java
+++ b/backend/src/main/java/com/jasonpyau/service/ContactService.java
@@ -2,7 +2,6 @@ package com.jasonpyau.service;
 
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,16 +14,15 @@ import com.jasonpyau.repository.ContactRepository;
 import com.jasonpyau.util.DateFormat;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class ContactService {
     
-    @Autowired
-    private ContactRepository contactRepository;
-    @Autowired
-    private EmailService emailService;
-    @Autowired
-    private UserService userService;
+    private final ContactRepository contactRepository;
+    private final EmailService emailService;
+    private final UserService userService;
 
     public void sendMessage(HttpServletRequest request, Message message) {
         String name = message.getName();

--- a/backend/src/main/java/com/jasonpyau/service/EmailService.java
+++ b/backend/src/main/java/com/jasonpyau/service/EmailService.java
@@ -1,19 +1,20 @@
 package com.jasonpyau.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Service
 public class EmailService {
     
     private static String fromEmail;
     private static String toEmail;
     
-    @Autowired
-    private JavaMailSender mailSender;
+    private final JavaMailSender mailSender;
 
     @Value("${spring.mail.username}")
     @SuppressWarnings("static-access")

--- a/backend/src/main/java/com/jasonpyau/service/ExperienceService.java
+++ b/backend/src/main/java/com/jasonpyau/service/ExperienceService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
 import com.jasonpyau.entity.Experience.ExperienceType;
+import com.jasonpyau.entity.Experience.Position;
+import com.jasonpyau.exception.ResourceAlreadyExistsException;
 import com.jasonpyau.exception.ResourceNotFoundException;
 import com.jasonpyau.repository.ExperienceRepository;
 import com.jasonpyau.util.CacheUtil;
@@ -38,11 +40,8 @@ public class ExperienceService {
 
     @CacheEvict(cacheNames = CacheUtil.EXPERIENCE_CACHE, allEntries = true)
     public void newExperience(Experience experience) {
-        if (experience.getPresent()) {
-            experience.syncEndDate();
-        } else {
-            experience.createOrder();
-        }
+        experience.syncEndDate();
+        experience.createOrder();
         experienceRepository.save(experience);
     }
 
@@ -53,12 +52,14 @@ public class ExperienceService {
             throw new ResourceNotFoundException(Experience.EXPERIENCE_ID_ERROR);
         }
         Experience experience = optional.get();
-        Patch.merge(updateExperience, experience, "id", "dateOrder");
+        Patch.merge(updateExperience, experience, "id", "dateOrder", "positions");
         Set<ConstraintViolation<Experience>> violations = validator.validate(experience);
         if (!violations.isEmpty()) {
             throw new ConstraintViolationException(violations);
         }
-        newExperience(experience);
+        experience.syncEndDate();
+        experience.createOrder();
+        experienceRepository.save(experience);
     }
 
     @CacheEvict(cacheNames = {CacheUtil.EXPERIENCE_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
@@ -106,6 +107,39 @@ public class ExperienceService {
         experienceRepository.save(experience);
     }
 
+    @CacheEvict(cacheNames = {CacheUtil.EXPERIENCE_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
+    public void newExperiencePosition(Position position, Integer id) {
+        Optional<Experience> experienceOptional = experienceRepository.findById(id);
+        if (!experienceOptional.isPresent()) {
+            throw new ResourceNotFoundException(Experience.EXPERIENCE_ID_ERROR);
+        }
+        Experience experience = experienceOptional.get();
+        if (experience.getPosition(position.getPositionName()).isPresent()) {
+            throw new ResourceAlreadyExistsException(Position.EXPERIENCE_POSITION_ALREADY_EXISTS_ERROR);
+        }
+        experience.getPositions().add(position);
+        experience.syncEndDate();
+        experience.createOrder();
+        experienceRepository.save(experience);
+    }
+
+    @CacheEvict(cacheNames = {CacheUtil.EXPERIENCE_CACHE, CacheUtil.SKILL_CACHE}, allEntries = true)
+    public void deleteExperiencePosition(String positionName, Integer id) {
+        Optional<Experience> experienceOptional = experienceRepository.findById(id);
+        if (!experienceOptional.isPresent()) {
+            throw new ResourceNotFoundException(Experience.EXPERIENCE_ID_ERROR);
+        }
+        Experience experience = experienceOptional.get();
+        Optional<Position> positionOptional = experience.getPosition(positionName);
+        if (!positionOptional.isPresent()) {
+            throw new ResourceNotFoundException(Position.EXPERIENCE_POSITION_NOT_FOUND_ERROR);
+        }
+        experience.getPositions().remove(positionOptional.get());
+        experience.syncEndDate();
+        experience.createOrder();
+        experienceRepository.save(experience);
+    }
+
     public List<String> validTypes() {
         return Experience.validTypes();
     }
@@ -125,7 +159,7 @@ public class ExperienceService {
         List<Experience> experiences = experienceRepository.findAll();
         for (Experience experience : experiences) {
             if (experience.syncEndDate()) {
-                System.out.printf("%s: Synced endDate for: '%s' at '%s'\n", DateFormat.MMddyyyyhhmmss(), experience.getPosition(), experience.getOrganization());
+                System.out.printf("%s: Synced endDate for: '%s'\n", DateFormat.MMddyyyyhhmmss(), experience.getOrganization());
                 experienceRepository.save(experience);
             }
         }

--- a/backend/src/main/java/com/jasonpyau/service/ExperienceService.java
+++ b/backend/src/main/java/com/jasonpyau/service/ExperienceService.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -25,15 +24,15 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class ExperienceService {
     
-    @Autowired
-    private ExperienceRepository experienceRepository;
+    private final ExperienceRepository experienceRepository;
 
-    @Autowired
-    private SkillService skillService;
+    private final SkillService skillService;
 
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 

--- a/backend/src/main/java/com/jasonpyau/service/LinkService.java
+++ b/backend/src/main/java/com/jasonpyau/service/LinkService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -21,15 +20,15 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class LinkService {
     
-    @Autowired
-    private LinkRepository linkRepository;
+    private final LinkRepository linkRepository;
 
-    @Autowired
-    private SimpleIconsService simpleIconsService;
+    private final SimpleIconsService simpleIconsService;
 
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 

--- a/backend/src/main/java/com/jasonpyau/service/MetadataService.java
+++ b/backend/src/main/java/com/jasonpyau/service/MetadataService.java
@@ -3,7 +3,6 @@ package com.jasonpyau.service;
 import java.util.Optional;
 import java.util.Set;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.jasonpyau.entity.Metadata;
@@ -16,12 +15,13 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class MetadataService {
 
-    @Autowired
-    private MetadataRepository metadataRepository;
+    private final MetadataRepository metadataRepository;
 
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
     

--- a/backend/src/main/java/com/jasonpyau/service/ProjectService.java
+++ b/backend/src/main/java/com/jasonpyau/service/ProjectService.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -23,15 +22,15 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class ProjectService {
 
-    @Autowired
-    private ProjectRepository projectRepository;
+    private final ProjectRepository projectRepository;
 
-    @Autowired
-    private SkillService skillService;
+    private final SkillService skillService;
 
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 

--- a/backend/src/main/java/com/jasonpyau/service/SkillService.java
+++ b/backend/src/main/java/com/jasonpyau/service/SkillService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -23,15 +22,15 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class SkillService {
 
-    @Autowired
-    private SkillRepository skillRepository;
+    private final SkillRepository skillRepository;
 
-    @Autowired
-    private SimpleIconsService simpleIconsService;
+    private final SimpleIconsService simpleIconsService;
 
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 

--- a/backend/src/main/java/com/jasonpyau/service/UserService.java
+++ b/backend/src/main/java/com/jasonpyau/service/UserService.java
@@ -2,7 +2,6 @@ package com.jasonpyau.service;
 
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -11,12 +10,13 @@ import com.jasonpyau.repository.UserRepository;
 import com.jasonpyau.util.Hash;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class UserService {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     private static String activeProfile;
 

--- a/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
+++ b/backend/src/main/java/com/jasonpyau/util/CacheUtil.java
@@ -2,7 +2,6 @@ package com.jasonpyau.util;
 
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -10,6 +9,9 @@ import org.springframework.stereotype.Component;
 
 import com.jasonpyau.service.RateLimitService;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Component
 @EnableCaching
 public class CacheUtil {
@@ -21,8 +23,7 @@ public class CacheUtil {
     public static final String ABOUT_ME_CACHE = "aboutMeCache";
     public static final String LINK_CACHE = "linkCache";
 
-    @Autowired
-    private RateLimitService rateLimitService;
+    private final RateLimitService rateLimitService;
 
     @Scheduled(fixedRateString = "${com.jasonpyau.cache.clear-rate:#{240}}", timeUnit = TimeUnit.MINUTES)
     @CacheEvict(cacheNames = {SKILL_CACHE, SIMPLE_ICONS_SVG_CACHE, PROJECT_CACHE, EXPERIENCE_CACHE, ABOUT_ME_CACHE, LINK_CACHE}, allEntries = true)

--- a/backend/src/main/resources/static/javascript/experiences.js
+++ b/backend/src/main/resources/static/javascript/experiences.js
@@ -36,26 +36,30 @@ function loadExperiences(experiences, type) {
         if (type === "WORK_EXPERIENCE") {
             experienceElement.innerHTML = `
                 <div class="Rounded Experience my-1 py-2 border border-white" id="Experience${experience.id}">
-                    <div class="fs-3 fw-bold mx-4 my-2" id="Position">
-                        ${experience.position}
+                    <div class="mx-4 my-1">
+                        ${experience.organizationLink ? `
+                            <a class="fs-3 fw-bold text-decoration-underline text-white opaque_when_hovered" id="Organization" title="${experience.organization}" href="${experience.organizationLink}" target="_blank">${experience.organization}</a>
+                            `:`
+                            <span class="fs-3 fw-bold text-decoration-underline" id="Organization">${experience.organization}</span>
+                        `}
+                        <span class="fs-6 fw-semibold mx-1" id="Location">- ${experience.location}</span>   
                     </div>
                     <div class="d-flex mx-4">
                         <div class="w-100 mx-2">
-                            <div class="fs-5 my-1" title="${experience.organization} - ${experience.location}">
-                                ${experience.organizationLink ? `
-                                    <a class="fw-bold text-decoration-underline text-white opaque_when_hovered" id="Organization" href="${experience.organizationLink}" target="_blank">${experience.organization}</a>
-                                    `:`
-                                    <span class="fw-bold text-decoration-underline" id="Organization">${experience.organization}</span>
-                                `}
-                                <span class="fw-semibold" id="Location">- ${experience.location}</span>   
-                            </div>
-                            <div class="fs-6 my-1 fw-semibold" id="DateContainer">
-                                <span id="StartDate">${experience.startDate}</span>
-                                <span>-</span>
-                                <span id="EndDate">${experience.present ? "Present" : experience.endDate}</span>
-                                <span>·</span>
-                                <span class="fst-italic" id="TimeElasped">${getYrsAndMos(experience.startDate, experience.endDate)}</span>
-                            </div>
+                            ${(experience.positions.map((position) => `
+                                <div class="mx-1 my-2">
+                                    <div class="fs-5 fw-bold" id="Position">
+                                        ${position.positionName}
+                                    </div>
+                                    <div class="fs-6 mx-1 fw-semibold" id="DateContainer">
+                                        <span id="StartDate">${position.startDate}</span>
+                                        <span>-</span>
+                                        <span id="EndDate">${position.present ? "Present" : position.endDate}</span>
+                                        <span>·</span>
+                                        <span class="fst-italic" id="TimeElasped">${getYrsAndMos(position.startDate, position.endDate)}</span>
+                                    </div>
+                                </div>
+                            `)).join("")}
                             <div class="fs-6 my-4 fw-semibold me-3" id="Body">
                                 ${experience.body}
                             </div>
@@ -65,7 +69,7 @@ function loadExperiences(experiences, type) {
                         ${experience.organizationLink ? `<a href="${experience.organizationLink}" target="_blank" class="opaque_when_hovered">` : ""}
                             <img class="ExperienceLogo my-3" height="180px" width="180px" src="${experience.logoLink}" title="${experience.organization}" alt="${experience.organization} Logo" loading="lazy"/>
                         ${experience.organizationLink ? `</a>` : ""}
-                        </div>
+                    </div>
                 </div>
             `;
         } else if (type === "EDUCATION") {
@@ -80,14 +84,18 @@ function loadExperiences(experiences, type) {
                     </div>
                     <div class="d-flex mx-4">
                         <div class="w-100 mx-2">
-                            <div class="fs-5 my-1">
-                                ${experience.position}
-                            </div>
-                            <div class="fs-6 my-1 fw-semibold" id="DateContainer">
-                                <span id="StartDate">${experience.startDate}</span>
-                                <span>-</span>
-                                <span id="EndDate">${experience.present ? "Present" : experience.endDate}</span>
-                            </div>
+                            ${(experience.positions.map((position) => `
+                                <div class="mx-1 my-2">
+                                    <div class="fs-5 fw-bold" id="Position">
+                                        ${position.positionName}
+                                    </div>
+                                    <div class="fs-6 mx-1 fw-semibold" id="DateContainer" title="${getYrsAndMos(position.startDate, position.endDate)}">
+                                        <span id="StartDate">${position.startDate}</span>
+                                        <span>-</span>
+                                        <span id="EndDate">${position.present ? "Present" : position.endDate}</span>
+                                    </div>
+                                </div>
+                            `)).join("")}
                             <div class="fs-6 my-4 fw-semibold me-3" id="Body">
                                 ${experience.body}
                             </div>

--- a/backend/src/test/java/com/jasonpyau/controller/ExperienceControllerTest.java
+++ b/backend/src/test/java/com/jasonpyau/controller/ExperienceControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
 import com.jasonpyau.entity.Experience.ExperienceType;
+import com.jasonpyau.entity.Experience.Position;
 import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.repository.ExperienceRepository;
 import com.jasonpyau.service.ExperienceService;
@@ -35,12 +36,8 @@ public class ExperienceControllerTest {
 
     private Experience experience = Experience.builder()
                                         .id(1)
-                                        .position("Software Engineer Intern")
                                         .organization("Meta")
                                         .location("Menlo Park, CA")
-                                        .startDate("05/2024")
-                                        .endDate("08/2024")
-                                        .present(false)
                                         .body("Software Engineer Intern working on engineering software at Meta as an Intern.")
                                         .logoLink("https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Meta_Platforms_Inc._logo_%28cropped%29.svg/75px-Meta_Platforms_Inc._logo_%28cropped%29.svg.png")
                                         .organizationLink(null)
@@ -54,10 +51,18 @@ public class ExperienceControllerTest {
                             .simpleIconsIconSlug("spring")
                             .hexFill("#ffffff")
                             .build();
+
+    private Position position = Position.builder()
+                                        .positionName("Software Engineer Intern")
+                                        .startDate("05/2024")
+                                        .endDate("08/2024")
+                                        .present(false)
+                                        .build();
     
     @BeforeEach
     public void setUp() {
         experience.getSkills().add(skill);
+        experience.getPositions().add(position);
     }
     
     @Test
@@ -72,12 +77,13 @@ public class ExperienceControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE", hasSize(1)))
             .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].id", is(experience.getId())))
-            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].position", is(experience.getPosition())))
             .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].organization", is(experience.getOrganization())))
             .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].location", is(experience.getLocation())))
-            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].startDate", is(experience.getStartDate())))
-            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].endDate", is(experience.getEndDate())))
-            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].present", is(experience.getPresent())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].positions", hasSize(1)))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].positions[0].positionName", is(position.getPositionName())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].positions[0].startDate", is(position.getStartDate())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].positions[0].endDate", is(position.getEndDate())))
+            .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].positions[0].present", is(position.getPresent())))
             .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].body", is(experience.getBody())))
             .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills", hasSize(1)))
             .andExpect(jsonPath("$.experiences.WORK_EXPERIENCE[0].skills[0].id", is(skill.getId())))

--- a/backend/src/test/java/com/jasonpyau/service/ExperienceServiceTest.java
+++ b/backend/src/test/java/com/jasonpyau/service/ExperienceServiceTest.java
@@ -2,6 +2,7 @@ package com.jasonpyau.service;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.jasonpyau.entity.Experience;
 import com.jasonpyau.entity.Skill;
 import com.jasonpyau.entity.Experience.ExperienceType;
+import com.jasonpyau.entity.Experience.Position;
 import com.jasonpyau.entity.Skill.SkillType;
 import com.jasonpyau.exception.ResourceNotFoundException;
 import com.jasonpyau.repository.ExperienceRepository;
@@ -38,12 +40,8 @@ public class ExperienceServiceTest {
     private Experience experience = Experience.builder()
                                         .id(1)
                                         .type(ExperienceType.WORK_EXPERIENCE)
-                                        .position("Software Engineer Intern")
                                         .organization("Meta")
                                         .location("Menlo Park, CA")
-                                        .startDate("05/2024")
-                                        .endDate("08/2024")
-                                        .present(false)
                                         .body("Software Engineer Intern working on engineering software at Meta as an Intern.")
                                         .logoLink("https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Meta_Platforms_Inc._logo_%28cropped%29.svg/75px-Meta_Platforms_Inc._logo_%28cropped%29.svg.png")
                                         .organizationLink(null)
@@ -58,14 +56,23 @@ public class ExperienceServiceTest {
                             .hexFill("#ffffff")
                             .build();
 
+    private Position position = Position.builder()
+                                        .positionName("Software Engineer Intern")
+                                        .startDate("05/2024")
+                                        .endDate("08/2024")
+                                        .present(false)
+                                        .build();
+
+    @BeforeEach
+    public void setUp() {
+        experience.getPositions().add(position);
+    }
+
     @Test
     public void testUpdateExperience() {
         given(experienceRepository.findById(1)).willReturn(Optional.of(experience));
         Experience updateExperience = new Experience();
-        updateExperience.setPosition("Software Engineer");
-        updateExperience.setStartDate("09/2024");
-        updateExperience.setEndDate("09/2024");
-        updateExperience.setPresent(true);
+        updateExperience.setBody(".".repeat(2000));
         assertDoesNotThrow(() -> {
             experienceService.updateExperience(updateExperience, 1);
         });
@@ -75,15 +82,12 @@ public class ExperienceServiceTest {
     public void testUpdateExperience_ConstraintViolationException() {
         given(experienceRepository.findById(1)).willReturn(Optional.of(experience));
         Experience updateExperience = new Experience();
-        updateExperience.setPosition("Software Engineer");
-        updateExperience.setStartDate("09/2024");
-        updateExperience.setEndDate("Not an end date");
-        updateExperience.setPresent(true);
+        updateExperience.setBody(".".repeat(2001));
         ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> {
             experienceService.updateExperience(updateExperience, 1);
         });
         assertEquals(e.getConstraintViolations().size(), 1);
-        assertEquals(e.getConstraintViolations().iterator().next().getMessage(), Experience.EXPERIENCE_END_DATE_ERROR);
+        assertEquals(e.getConstraintViolations().iterator().next().getMessage(), Experience.EXPERIENCE_BODY_ERROR);
     }
 
     @Test


### PR DESCRIPTION
- Bump Spring Boot 4.1.0: CVE-2026-29062, CVE-2026-54512, CVE-2026-54513, CVE-2026-54518, CVE-2026-54514, CVE-2026-54516, CVE-2026-54517, CVE-2026-34479, CVE-2026-34477, CVE-2026-40974, CVE-2026-40971, CVE-2026-40976, CVE-2026-22731, CVE-2026-22733, CVE-2026-40972, CVE-2026-40975, CVE-2026-40973, CVE-2026-40970, CVE-2026-40977, CVE-2026-41838, CVE-2026-41842, CVE-2026-41848, CVE-2026-41850, CVE-2026-41851, CVE-2026-22740, CVE-2026-41854, CVE-2026-41844, CVE-2026-41845, CVE-2026-41846, CVE-2026-22737, CVE-2026-41840, CVE-2026-41841, CVE-2026-41843, CVE-2026-22745, CVE-2026-41852, CVE-2026-41853, CVE-2026-22741, CVE-2026-22735, CVE-2026-40477, CVE-2026-40478, CVE-2026-41293, CVE-2026-43512, CVE-2026-29145, CVE-2026-43515, CVE-2026-24734, CVE-2026-24880, CVE-2026-29146, CVE-2026-34483, CVE-2026-34487, CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-34500, CVE-2026-25854, CVE-2026-32990, CVE-2026-43514
- Refactor Experience.java so that an experience is able to have multiple positions (postitionName, startDate, endDate, present). The following SQL commands need to be ran on MariaDB to migrate these changes successfully: 
```sql
ALTER TABLE `experiences` ADD `positions` LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
UPDATE `experiences` SET `positions` = '[]' where `positions` IS NULL OR TRIM(`positions`) = '';

ALTER TABLE `experiences`
  DROP `end_date`,
  DROP `position`,
  DROP `present`,
  DROP `start_date`;
```
- Fix VS Code warnings/errors: JAVA_REPOSITORY, JAVA_CONSTRUCTOR_PARAMETER_INJECTION (See https://github.com/spring-projects/spring-tools/blob/6e4ee1bad0ef5bb31331539fa50469ae4889a717/vscode-extensions/vscode-spring-boot/package.json)